### PR TITLE
Add Dockerfile and GitHub Actions workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,48 @@
+name: Docker
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - '*'
+
+jobs:
+  build-and-push-image:
+    name: Build and push image
+    runs-on: ubuntu-latest
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: "recursive"
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=edge
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to the container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.gitignore
+++ b/.gitignore
@@ -45,4 +45,5 @@ CMakeUserPresets.json
 /NETWORK
 /testnet*
 /tmp
-
+/.idea
+/_deps

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM alpine:3 AS builder
+RUN apk add --update --no-cache git build-base cmake libsecp256k1-dev rocksdb-dev libsodium-dev zlib-dev gmp-dev ccache
+WORKDIR /app
+COPY . .
+RUN git submodule update --init --recursive
+RUN --mount=type=cache,target=/root/.cache/ccache sh make_release.sh "-DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
+
+FROM alpine:3
+RUN apk add --update --no-cache bash libsecp256k1 rocksdb libsodium zlib gmp libgomp
+WORKDIR /app
+COPY --from=builder /app/build ./build
+COPY ["activate.sh", "run_*.sh", "docker-entrypoint.sh", "./"]
+COPY config ./config
+COPY kernel ./kernel
+COPY www ./www
+VOLUME /app/config/local
+
+ENTRYPOINT ["./docker-entrypoint.sh"]
+CMD ["./run_node.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,8 @@ COPY ["activate.sh", "run_*.sh", "docker-entrypoint.sh", "./"]
 COPY config ./config
 COPY kernel ./kernel
 COPY www ./www
-VOLUME /app/config/local
+ENV MMX_HOME="/data/"
+VOLUME /data
 
 ENTRYPOINT ["./docker-entrypoint.sh"]
 CMD ["./run_node.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,14 @@ COPY ["activate.sh", "run_*.sh", "docker-entrypoint.sh", "./"]
 COPY config ./config
 COPY kernel ./kernel
 COPY www ./www
+
 ENV MMX_HOME="/data/"
 VOLUME /data
+
+# node p2p port
+EXPOSE 12336/tcp
+# http api port
+EXPOSE 11380/tcp
 
 ENTRYPOINT ["./docker-entrypoint.sh"]
 CMD ["./run_node.sh"]

--- a/activate.sh
+++ b/activate.sh
@@ -1,24 +1,25 @@
 #!/bin/bash
 
-if [ ! -d config/local ]; then
-	cp -r config/local_init config/local
-	echo "Initialized config/local/ with defaults."
+if [ ! -d "${MMX_HOME}config/local" ]; then
+	mkdir -p "${MMX_HOME}config/"
+	cp -r config/local_init "${MMX_HOME}config/local"
+	echo "Initialized ${MMX_HOME}config/local/ with defaults."
 fi
 
-if [ ! -f config/local/passwd ] || [[ $(cat config/local/passwd | wc -c) -lt 64 ]]; then
-	./build/generate_passwd > config/local/passwd
-	./build/vnx-base/tools/vnxpasswd -c config/default/ config/local/ -u mmx-admin -p $(cat config/local/passwd)
+if [ ! -f "${MMX_HOME}config/local/passwd" ] || [[ $(cat "${MMX_HOME}config/local/passwd" | wc -c) -lt 64 ]]; then
+	./build/generate_passwd > "${MMX_HOME}config/local/passwd"
+	./build/vnx-base/tools/vnxpasswd -c config/default/ "${MMX_HOME}config/local/" -u mmx-admin -p $(cat "${MMX_HOME}config/local/passwd")
 fi
 
-chmod 600 config/local/passwd
-cp config/local/passwd PASSWD
-echo "PASSWD=$(cat PASSWD)"
+chmod 600 "${MMX_HOME}config/local/passwd"
+cp "${MMX_HOME}config/local/passwd" "${MMX_HOME}PASSWD"
+echo "PASSWD=$(cat "${MMX_HOME}PASSWD")"
 
-if [ -f NETWORK ]; then
-	NETWORK=$(cat NETWORK)
+if [ -f "${MMX_HOME}NETWORK" ]; then
+	NETWORK=$(cat "${MMX_HOME}NETWORK")
 else
 	NETWORK=testnet6
-	echo ${NETWORK} > NETWORK
+	echo ${NETWORK} > "${MMX_HOME}NETWORK"
 fi
 
 echo NETWORK=${NETWORK}

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -em
+
+source ./activate.sh
+
+"$@"

--- a/run_exch_server.sh
+++ b/run_exch_server.sh
@@ -2,4 +2,4 @@
 
 source ./activate.sh
 
-mmx_exch_server -c config/${NETWORK}/ config/local/
+mmx_exch_server -c config/${NETWORK}/ "${MMX_HOME}config/local/"

--- a/run_farmer.sh
+++ b/run_farmer.sh
@@ -2,5 +2,4 @@
 
 source ./activate.sh
 
-mmx_farmer -c config/${NETWORK}/ config/farmer/ config/local/ $@
-
+mmx_farmer -c config/${NETWORK}/ config/farmer/ "${MMX_HOME}config/local/" $@

--- a/run_harvester.sh
+++ b/run_harvester.sh
@@ -2,5 +2,4 @@
 
 source ./activate.sh
 
-mmx_harvester -c config/${NETWORK}/ config/farmer/ config/local/ $@
-
+mmx_harvester -c config/${NETWORK}/ config/farmer/ "${MMX_HOME}config/local/" $@

--- a/run_light_node.sh
+++ b/run_light_node.sh
@@ -2,5 +2,4 @@
 
 source ./activate.sh
 
-mmx_node -c config/${NETWORK}/ config/node/ config/light_mode/ config/local/ $@
-
+mmx_node -c config/${NETWORK}/ config/node/ config/light_mode/ "${MMX_HOME}config/local/" $@

--- a/run_node.sh
+++ b/run_node.sh
@@ -2,5 +2,4 @@
 
 source ./activate.sh
 
-mmx_node -c config/${NETWORK}/ config/node/ config/local/ $@
-
+mmx_node -c config/${NETWORK}/ config/node/ "${MMX_HOME}config/local/" $@

--- a/run_timelord.sh
+++ b/run_timelord.sh
@@ -2,5 +2,4 @@
 
 source ./activate.sh
 
-mmx_timelord -c config/${NETWORK}/ config/timelord/ config/local/ $@
-
+mmx_timelord -c config/${NETWORK}/ config/timelord/ "${MMX_HOME}config/local/" $@

--- a/run_wallet.sh
+++ b/run_wallet.sh
@@ -2,5 +2,4 @@
 
 source ./activate.sh
 
-mmx_wallet -c config/${NETWORK}/ config/wallet/ config/local/ $@
-
+mmx_wallet -c config/${NETWORK}/ config/wallet/ "${MMX_HOME}config/local/" $@


### PR DESCRIPTION
Currently mmx-node does not have a Dockerfile or provides a docker image.

This PR adds a Dockerfile which can be built using buildx/BuildKit with caching using ccache to reduce buildtimes down to seconds.
The image runs the node by default (`run_node.sh`) but as its entrypoint sources `activate.sh` overriding the CMD with some custom command is always executed in an activated environment.

Additionally a github actions workflow is added to build and publish images for the master branch and tags, where master commits are tagged as `edge` and github tags/releases following the semver spec are tagged as `latest`, `1.2.3`, `1.2` and `1` to allow easy version management for users.

**Note**: currently buildx/BuildKit does not support exporting cache mounts and thus image builds on github actions take about 1h as ccache caches can not be used. See: https://github.com/moby/buildkit/issues/1512