### PR TITLE
Auto-cancel superfluous docker builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,6 +7,12 @@ on:
     tags:
       - '*'
 
+# Automatically cancel previous runs for the same ref (i.e. branch) and event type. The latter component prevents
+# manually dispatched events from being cancelled by pushes to the `master` branch.
+concurrency:
+  group: ${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: true
+
 jobs:
   build-and-push-image:
     name: Build and push image


### PR DESCRIPTION
Currently when multiple commits are pushed in short succession multiple docker image builds are started and run. Due to the varying performance of gha runners older runs might finish before newer runs resulting in an outdated image to be pushed.

This PR fixes this by auto canceling superfluous builds for same branch and event pushes.