### PR TITLE
Update p2p port in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ ENV MMX_HOME="/data/"
 VOLUME /data
 
 # node p2p port
-EXPOSE 12336/tcp
+EXPOSE 12337/tcp
 # http api port
 EXPOSE 11380/tcp
 


### PR DESCRIPTION
testnet7 uses a new port, but the Dockerfile was not updated accordingly