### PR TITLE
Fix `activate.sh` and use `dist` in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,12 +8,8 @@ RUN --mount=type=cache,target=/root/.cache/ccache sh make_release.sh "-DCMAKE_CX
 FROM alpine:3
 RUN apk add --update --no-cache bash libsecp256k1 rocksdb libsodium zlib gmp libgomp
 WORKDIR /app
-COPY --from=builder /app/build ./build
-COPY ["activate.sh", "run_*.sh", "docker-entrypoint.sh", "./"]
-COPY config ./config
-COPY kernel ./kernel
-COPY www ./www
-COPY data ./data
+COPY --from=builder /app/build/dist ./
+COPY ["docker-entrypoint.sh", "./"]
 
 ENV MMX_HOME="/data/"
 VOLUME /data

--- a/activate.sh
+++ b/activate.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 export PATH=$PATH:$PWD/bin:$PWD/build:$PWD/build/tools:$PWD/build/vnx-base/tools
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/lib:$PWD/build:$PWD/build/vnx-base:$PWD/build/vnx-addons:$PWD/build/basic-opencl
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/lib:$PWD/lib64:$PWD/build:$PWD/build/vnx-base:$PWD/build/vnx-addons:$PWD/build/basic-opencl
 
 if [[ -z "${MMX_HOME}" ]]; then
 	export MMX_HOME="$PWD/"


### PR DESCRIPTION
Currently the `activate.sh` is missing the `lib64` directory in its lib includes, causing it to error out on use if run from `dist`.

Additionally the docker builds will now use the `dist` directory provided by the install directive in `make_release.sh`.