### PR TITLE
AVX vs SSE4.2 as baseline (rec SHA256 performance)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ if(MSVC)
 	add_compile_options(/openmp /EHsc /MP)
 
 	set(MSVC_DEBUG_OPTIONS /Od)
-	set(MSVC_RELEASE_OPTIONS /W1 /O2 /arch:AVX)
+	set(MSVC_RELEASE_OPTIONS /W1 /O2)
 
 	add_compile_options( 
 		"$<$<CONFIG:Debug>:${MSVC_DEBUG_OPTIONS}>"
@@ -243,6 +243,9 @@ if(MSVC)
 
 	set_target_properties(mmx_vm PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS 1)
 	set_target_properties(mmx_db PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS 1)
+
+	set_source_files_properties(src/sha256_ni.cpp PROPERTIES COMPILE_FLAGS "/arch:AVX")
+	set_source_files_properties(src/sha256_ni_rec.cpp PROPERTIES COMPILE_FLAGS "/arch:AVX")
 
 	# Workaround for:
 	#	LNK1189: library limit of 65535 objects exceeded

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ if(MSVC)
 	add_compile_options(/openmp /EHsc /MP)
 
 	set(MSVC_DEBUG_OPTIONS /Od)
-	set(MSVC_RELEASE_OPTIONS /W1 /O2)
+	set(MSVC_RELEASE_OPTIONS /W1 /O2 /arch:AVX)
 
 	add_compile_options( 
 		"$<$<CONFIG:Debug>:${MSVC_DEBUG_OPTIONS}>"
@@ -258,8 +258,8 @@ else()
 	
 	if(${CMAKE_HOST_SYSTEM_PROCESSOR} STREQUAL "x86_64")
 		message(STATUS "Enabling -mavx2 -msha")
-		set_source_files_properties(src/sha256_ni.cpp PROPERTIES COMPILE_FLAGS "-msse4.2 -msha")
-		set_source_files_properties(src/sha256_ni_rec.cpp PROPERTIES COMPILE_FLAGS "-msse4.2 -msha")
+		set_source_files_properties(src/sha256_ni.cpp PROPERTIES COMPILE_FLAGS "-mavx -msha")
+		set_source_files_properties(src/sha256_ni_rec.cpp PROPERTIES COMPILE_FLAGS "-mavx -msha")
 		set_source_files_properties(src/sha256_avx2.cpp PROPERTIES COMPILE_FLAGS "-mavx2")
 	endif()
 endif()


### PR DESCRIPTION
PR for using (not now, in future) AVX (not AVX2) vs SSE4.2 as baseline.

_**NOTE**: Not important now, **can close at once** (only +1%, but real). A reference for future._
_NOTE: Going to document as optimization tip for TimeLord (for those who want it)._

Changes:
- Compile `recursive_sha256_ni()` with AVX vs SSE4.2.
- Change whole Win/VC++ compile to `/arch:AVX`.
- Change 2x files Linux to `-mavx` vs `-msse4.2`.

Observations:
- Real +1% effect on Intel 13th-Gen CPU, Linux/gcc12, Linux/Clang15, Win/VC++.
- Some older CPUs might work better with SSE4.2 (tested Intel 11th-Gen).