### PR TITLE
Log DEBUG(4) of best plot id and filepath

### DIFF
--- a/src/Harvester.cpp
+++ b/src/Harvester.cpp
@@ -257,6 +257,7 @@ void Harvester::lookup_task(std::shared_ptr<const Challenge> value, const int64_
 		try {
 			const auto proof = prover->get_full_proof(best_entry.challenge.bytes, best_entry.index);
 			send_response(value, proof, nullptr, best_entry.plot_id, best_entry.score, time_begin);
+			log(DEBUG) << "[" << host_name << "] Best plot id: " << best_entry.plot_id << " (" << prover->get_file_path() << ")";
 		} catch(const std::exception& ex) {
 			log(WARN) << "[" << host_name << "] Failed to fetch full proof: " << ex.what() << " (" << prover->get_file_path() << ")";
 		}


### PR DESCRIPTION
PR for DEBUG(4) logging of best plot id and filepath.

Goal: Tool to problemsolve/check situations if needed (triggered by question in `#mmx-support` Discord).

**QA needed (by Max):**
- Not sure of `prover->get_file_path()` if virtual plot (VP)

Changes:
- New `log(DEBUG)` in `Harvester.cpp` of best entry passed plot filter
- `[<hostname>] Best plot id: <plotid> (<filepath>)`

Tested:
- Tested Win/VC++ (1day, no problems, ok entries)