### PR TITLE
CPU OpenCL balanced VDF verify (draft)

### DIFF
--- a/config/default/Node.json
+++ b/config/default/Node.json
@@ -3,5 +3,6 @@
 	"sync_loss_delay": 180,
 	"max_fork_length": 1000,
 	"validate_interval_ms": 500,
+	"verify_vdf_multiple": false,
 	"verify_vdf_rewards": true
 }

--- a/config/local_init/Node.json
+++ b/config/local_init/Node.json
@@ -1,4 +1,5 @@
 {
 	"opencl_device": 0,
+	"verify_vdf_multiple": false,
 	"verify_vdf_rewards": true
 }

--- a/include/mmx/Node.h
+++ b/include/mmx/Node.h
@@ -382,6 +382,8 @@ private:
 
 	void verify_vdf(std::shared_ptr<const ProofOfTime> proof, const uint32_t chain) const;
 
+	void verify_vdf_cpuocl(std::shared_ptr<const ProofOfTime> proof) const;
+
 	void verify_vdf_success(std::shared_ptr<const ProofOfTime> proof, std::shared_ptr<vdf_point_t> point);
 
 	void verify_vdf_failed(std::shared_ptr<const ProofOfTime> proof);

--- a/include/mmx/OCL_VDF.h
+++ b/include/mmx/OCL_VDF.h
@@ -31,6 +31,8 @@ public:
 
 	void verify(std::shared_ptr<const ProofOfTime> proof, const uint32_t chain);
 
+	void compute_point(std::vector<hash_t>* point_p, std::vector<uint32_t>* num_iters_p, const size_t start_p, const size_t num_p);
+
 	static void release();
 
 private:

--- a/modules/Node.vni
+++ b/modules/Node.vni
@@ -47,6 +47,7 @@ module Node implements vnx.addons.HttpComponent {
 	bool db_replay = false;
 	bool show_warnings = false;
 	bool verify_vdf_rewards = true;
+	bool verify_vdf_multiple = false;			// verify VDF streams on cpu and opencl, if possible
 	
 	string storage_path;
 	string database_path = "db/";

--- a/src/Node.cpp
+++ b/src/Node.cpp
@@ -20,6 +20,8 @@
 #include <mmx/vm/Engine.h>
 #include <mmx/vm_interface.h>
 #include <mmx/Router.h>
+#include <sha256_ni.h>
+#include <sha256_avx2.h>
 
 #include <vnx/vnx.h>
 
@@ -111,6 +113,15 @@ void Node::main()
 		log(WARN) << "Failed to create OpenCL GPU context: " << ex.what();
 	}
 #endif
+
+	// TODO: remove temporary create/set 'verify_vdf_multiple' variable when generated vnx ready
+	bool verify_vdf_multiple = true;
+
+	if(auto engine = opencl_vdf[0]) {
+        	log(INFO) << "Verify on CPU and OpenCL " << ((sha256_ni_available() || avx2_available()) ? "possible" : "not possible") << " (setting: " << ((verify_vdf_multiple) ? "enabled" : "disabled") << ")";
+	} else {
+		log(INFO) << "Verify on CPU and OpenCL not possible (setting: " << (verify_vdf_multiple ? "enabled" : "disabled") << ")";
+	}
 
 	threads = std::make_shared<vnx::ThreadPool>(num_threads);
 	vdf_threads = std::make_shared<vnx::ThreadPool>(num_vdf_threads);

--- a/src/Node_verify.cpp
+++ b/src/Node_verify.cpp
@@ -458,13 +458,13 @@ void Node::verify_vdf_cpuocl(std::shared_ptr<const ProofOfTime> proof) const
 
 	// comment: hash all points, load balanced on cpu/opencl
 #pragma omp parallel for
-	for(uint32_t chunk = 0; chunk < async_num + 1; ++chunk)
+	for(int chunk = 0; chunk < (int)async_num + 1; ++chunk)
 	{
-		if(chunk < async_num) {
+		if(chunk < (int)async_num) {
 			// comment: cpu, async_num threads
 			time_cpu_start[chunk] = vnx::get_time_micros();
-			const uint32_t batch_real = (chunk < batch_full) ? batch_size : batch_size - 1;
-			const uint32_t batch_startp = (chunk < batch_full) ? (chunk * batch_size) : (batch_full * batch_size) + ((chunk - batch_full) * (batch_size - 1));
+			const uint32_t batch_real = (chunk < (int)batch_full) ? batch_size : batch_size - 1;
+			const uint32_t batch_startp = (chunk < (int)batch_full) ? (chunk * batch_size) : (batch_full * batch_size) + ((chunk - batch_full) * (batch_size - 1));
 
 			if(have_sha_ni) {
 				// comment: cpu, sha-ni

--- a/www/web-gui/public/locales/en.js
+++ b/www/web-gui/public/locales/en.js
@@ -291,6 +291,7 @@ const enLocale = {
         "enable_timelord_reward": "Enable TimeLord Rewards (requires one more CPU core)",
         "verify_timelord_reward": "Verify TimeLord Rewards (disable to speed up VDF verify)",
         "open_port": "Open network port to allow incoming connections (UPnP)",
+        "verify_vdf_multiple": "Verify on CPU and OpenCL (if possible, experimental)",
         "farmer_reward_address": "Farmer Reward Address",
         "timeLord_reward_address": "TimeLord Reward Address",
         "restart_needed": "(restart needed to apply)",

--- a/www/web-gui/public/settings.js
+++ b/www/web-gui/public/settings.js
@@ -7,6 +7,7 @@ Vue.component('node-settings', {
 			loading: true,
 			timelord: null,
 			open_port: null,
+			verify_vdf_multiple: null,
 			opencl_device: null,
 			opencl_platform: null,
 			opencl_device_list: null,
@@ -30,6 +31,7 @@ Vue.component('node-settings', {
 					this.loading = false;
 					this.timelord = data.timelord ? true : false;
 					this.open_port = data["Router.open_port"] ? true : false;
+					this.verify_vdf_multiple = data["Node.verify_vdf_multiple"] != null ? true : false;
 					this.opencl_platform = data["opencl.platform"] != null ? data["opencl.platform"] : "";
 					this.opencl_device = data["Node.opencl_device"] != null ? data["Node.opencl_device"] : 0;
 					this.opencl_device_list = [{name: "None", value: -1}];
@@ -157,6 +159,11 @@ Vue.component('node-settings', {
 				this.set_config("Router.open_port", value, true);
 			}
 		},
+		verify_vdf_multiple(value, prev) {
+			if(prev != null) {
+				this.set_config("Node.verify_vdf_multiple", value, true);
+			}
+		},
 		opencl_platform(value, prev) {
 			if(prev != null) {
 				this.set_config("opencl.platform", value, true);
@@ -258,6 +265,11 @@ Vue.component('node-settings', {
 					<v-checkbox
 						v-model="open_port"
 						:label="$t('node_settings.open_port')"
+						class="my-0"
+					></v-checkbox>
+					<v-checkbox
+						v-model="verify_vdf_multiple"
+						:label="$t('node_settings.verify_vdf_multiple')"
 						class="my-0"
 					></v-checkbox>
 					


### PR DESCRIPTION
PR to discuss possible CPU/OpenCL load balanced VDF verify.

_NOTE: Draft version. Not intended as real PR, only discussion._

**Goal:** Async/balanced usage of CPU/OpenCL to shorten verify VDF time.
**Goal:** Keep-it-simple, adhere to existing code, no new libraries.

**Questions:**
- Viable solution, other ways, suggestions, improvements ?
- Need to get `verify_vdf_multiple` into VNX structure, how ?
- Ok to use `opencl_vdf[0]` this way ? 
- Recommended place to store `prev_time_` & `prev_num_` between blocks ?
- Honest feedback best. Zero problem with:
  - Seriously, rename `<tbd>` to `...` :-)
  - Not important, not a priority
  - You'll code it yourself, faster & better, in the future

_PS: A few comments in code for easier parsing. Will be removed when/if final version._

Changes:
- New SETTINGS option to enable `verify_vdf_multiple`
- New verify VDF codepath `verify_vdf_cpuocl()` in `Node_verify.cpp`
- New verify VDF GPU subset points `compute_point()` in `OCL_VDF.cpp`

Lots left to code/test/QA (in-progress):
- Tune/check code (some in comments)
- gcc/Clang/VC++ (Linux/Windows)
- A few different PC/hardware have available

Testing (limited):
- TimeLord: 24.8 MH/s (3x VDF streams)
- CPU: Intel 13th-gen 8P+0E (HT:on) @4.8GHz
- GPU: Nvidia GT 1030
- CPU(only): **2.04 sec** / GPU(only): **2.18 sec** / CPU+GPU: **1.22 sec**

_PS: Done more extreme (cores on/off) balance, both ways, quickly (1x block) balances workload._
