### PR TITLE
CPU OpenCL balanced VDF verify (Rev01)

### DIFF
--- a/config/default/Node.json
+++ b/config/default/Node.json
@@ -3,5 +3,6 @@
 	"sync_loss_delay": 180,
 	"max_fork_length": 1000,
 	"validate_interval_ms": 500,
+	"verify_vdf_cpuopencl": false,
 	"verify_vdf_rewards": true
 }

--- a/config/default/Node.json
+++ b/config/default/Node.json
@@ -3,6 +3,5 @@
 	"sync_loss_delay": 180,
 	"max_fork_length": 1000,
 	"validate_interval_ms": 500,
-	"verify_vdf_cpuopencl": false,
 	"verify_vdf_rewards": true
 }

--- a/config/local_init/Node.json
+++ b/config/local_init/Node.json
@@ -1,4 +1,5 @@
 {
 	"opencl_device": 0,
+	"verify_vdf_cpuopencl": false,
 	"verify_vdf_rewards": true
 }

--- a/modules/Node.vni
+++ b/modules/Node.vni
@@ -46,6 +46,7 @@ module Node implements vnx.addons.HttpComponent {
 	bool do_sync = true;
 	bool db_replay = false;
 	bool show_warnings = false;
+	bool verify_vdf_cpuopencl = false;			// verify VDF streams on cpu and opencl, if possible
 	bool verify_vdf_rewards = true;
 	
 	string storage_path;

--- a/src/Node_verify.cpp
+++ b/src/Node_verify.cpp
@@ -405,7 +405,7 @@ void Node::verify_vdf_task(std::shared_ptr<const ProofOfTime> proof) const noexc
 		for(int i = 0; i < 3; ++i) {
 			if(i < 2 || (verify_vdf_rewards && proof->reward_addr)) {
 				if(auto engine = opencl_vdf[i]) {
-					if(!(verify_vdf_cpuopencl && i < 1)) {
+					if(i > 0 || !verify_vdf_cpuopencl) {
 						engine->compute(proof, i);
 					}
 				}
@@ -416,12 +416,9 @@ void Node::verify_vdf_task(std::shared_ptr<const ProofOfTime> proof) const noexc
 		for(int i = 0; i < 3; ++i) {
 			if(i < 2 || (verify_vdf_rewards && proof->reward_addr)) {
 				try {
-					if(auto engine = opencl_vdf[i]) {
-						if(!(verify_vdf_cpuopencl && i < 1)) {
-							engine->verify(proof, i);
-						} else {
-							verify_vdf(proof, i);
-						}
+					auto engine = opencl_vdf[i];
+					if(engine && (i > 0 || !verify_vdf_cpuopencl)) {
+						engine->verify(proof, i);
 					} else {
 						verify_vdf(proof, i);
 					}

--- a/src/Node_verify.cpp
+++ b/src/Node_verify.cpp
@@ -397,12 +397,17 @@ void Node::verify_vdf_task(std::shared_ptr<const ProofOfTime> proof) const noexc
 {
 	std::lock_guard lock(vdf_mutex);
 
+	// TODO: remove temporary create/set 'verify_vdf_cpuopencl' variable when generated VNX ready
+	bool verify_vdf_cpuopencl = true;
+
 	const auto time_begin = vnx::get_wall_time_micros();
 	try {
 		for(int i = 0; i < 3; ++i) {
 			if(i < 2 || (verify_vdf_rewards && proof->reward_addr)) {
 				if(auto engine = opencl_vdf[i]) {
-					engine->compute(proof, i);
+					if(!(verify_vdf_cpuopencl && i < 1)) {
+						engine->compute(proof, i);
+					}
 				}
 			}
 		}
@@ -412,7 +417,11 @@ void Node::verify_vdf_task(std::shared_ptr<const ProofOfTime> proof) const noexc
 			if(i < 2 || (verify_vdf_rewards && proof->reward_addr)) {
 				try {
 					if(auto engine = opencl_vdf[i]) {
-						engine->verify(proof, i);
+						if(!(verify_vdf_cpuopencl && i < 1)) {
+							engine->verify(proof, i);
+						} else {
+							verify_vdf(proof, i);
+						}
 					} else {
 						verify_vdf(proof, i);
 					}


### PR DESCRIPTION
PR for optional concurrent CPU/OpenCL VDF verify.

**Goal**: Optional (simplified) concurrent usage of CPU/OpenCL.
**Goal**: Solve 5sec VDF verify edge, in some use-cases (limited).

**Questions:**
- Worth it ? Extra mmx-node configuration permutations (end-user) ? More problems/questions than solves. Better to require good enough GPU/iGPU. Always the tip to try 2x VDF streams, and if GPU/iGPU cannot handle that, upgrade.
- Or maybe, as 13900KS illustrates below. A low-power MiniPC/NUC with balanced CPU/iGPU, just on the 5sec edge (even with 2x streams). This option could make it a viable hardware choice.

Logic:
- Manual option, no GUI, `verify_vdf_cpuopencl`, default: `false`
- If `true` and OpenCL device:
  - 2x VDF streams (no verify TL rewards)
    - `[1] engine->compute (GPU)` _(load work, returns)_
    - `[0] verify_vdf (CPU)` _(cpu verify, opencl in background)_
    - `[1] engine->compute (GPU)`
  - 3x VDF streams (verify TL rewards)
    - `[1] engine->compute (GPU)` _(load work, returns)_
    - `[2] engine->compute (GPU)` _(load work, returns)_
    - `[0] verify_vdf (CPU)` _(cpu verify, opencl in background)_
    - `[1] engine->compute (GPU)`
    - `[2] engine->compute (GPU)`
- Descriptive:
  - If option enabled, and OpenCL device is active for VDF verify.
  - Switch stream 0 to CPU, keep rest on OpenCL (async).
  - No verify TL rewards: 1/2 (50%) work on CPU, 1/2 (50%) work on OpenCL.
  - If verify TL rewards: 1/3 (33%) work on CPU, 2/3 (66%) work on OpenCL.

Testing:
- TimeLord: 24.8 MH/s (3x VDF streams)
- CPU/GPU: Intel i9-13900KS 8C/16T @4.8GHz (8P+0E), Nvidia GT 1030
  - 2x streams: `0.73` vs `1.45` sec, `-49%` (enabled/disabled)
  - 3x streams: `1.44` vs `2.16` sec, `-33%` (enabled/disabled)
- CPU/GPU: Intel i7-8700K 6C/12T @4.2GHz, Nvidia GT 1030
  - 2x streams: `2.00` vs `1.48` sec, `+33%` (enabled/disabled)
  - 3x streams: `1.94` vs `2.23` sec, `-13%` (enabled/disabled)
- Observation:
  - 13900KS(SHA-NI)/GT1030 with disabled E-cores, locked to @4.8GHz have very even performance between CPU and OpenCL. Good example of max utilization of CPU/OpenCL concurrency.
  - 8700K(AVX2)/GT1030 is not evenly matched. CPU largely outmatched by OpenCL. Just about helps for 3x streams, but 2x streams makes it worse.