### PR TITLE
Use recursive_sha256_ni_x2() for verify VDF

### DIFF
--- a/src/Node_verify.cpp
+++ b/src/Node_verify.cpp
@@ -295,6 +295,7 @@ void Node::verify_vdf(std::shared_ptr<const ProofOfTime> proof, const uint32_t c
 		const auto num_lanes = std::min<uint32_t>(batch_size, segments.size() - chunk * batch_size);
 
 		uint32_t max_iters = 0;
+		uint32_t min_iters = 0;
 		hash_t point[batch_size];
 		uint8_t hash[batch_size][32];
 		uint8_t input[batch_size][64];
@@ -320,22 +321,19 @@ void Node::verify_vdf(std::shared_ptr<const ProofOfTime> proof, const uint32_t c
 			for(uint32_t j = 0; j < num_lanes; j += 2)
 			{
 				const uint32_t i = chunk * batch_size + j;
+				const uint32_t k = (j + 1 < num_lanes) ? 1 : 0;
 				uint8_t hashx2[32 * 2];
+				max_iters = std::max(segments[i].num_iters, segments[i + k].num_iters);
+				min_iters = std::min(segments[i].num_iters, segments[i + k].num_iters);
 
-				if(j + 1 >= num_lanes) {
-					recursive_sha256_ni(point[j].data(), segments[i].num_iters);
+				::memcpy(hashx2, point[j].data(), 32);
+				::memcpy(hashx2 + 32, point[j + k].data(), 32);
+				recursive_sha256_ni_x2(hashx2, min_iters);
+				if(max_iters != min_iters) {
+					recursive_sha256_ni(hashx2 + ((segments[i].num_iters > segments[i + k].num_iters) ? 0 : 32), max_iters - min_iters);
 				}
-				else if(segments[i].num_iters != segments[i + 1].num_iters) {
-					recursive_sha256_ni(point[j].data(), segments[i].num_iters);
-					recursive_sha256_ni(point[j + 1].data(), segments[i + 1].num_iters);
-				}
-				else {
-					::memcpy(hashx2, point[j].data(), 32);
-					::memcpy(hashx2 + 32, point[j + 1].data(), 32);
-					recursive_sha256_ni_x2(hashx2, segments[i].num_iters);
-					::memcpy(point[j].data(), hashx2, 32);
-					::memcpy(point[j + 1].data(), hashx2 + 32, 32);
-				}
+				::memcpy(point[j].data(), hashx2, 32);
+				::memcpy(point[j + k].data(), hashx2 + 32, 32);
 			}
 		} else {
 			for(uint32_t k = 0; k < max_iters; ++k)


### PR DESCRIPTION
PR for use of `recursive_sha256_ni_x2()` with verify VDF (CPU's w/SHA extensions).

**Goal:** Increase any unused performance in CPU pipeline.
**Goal:** Check for any regression vs existing processing.

Logic:
- Process points/hash'es two at a time (if CPU w/SHA extensions)
  - Exception: If odd number of inner loop points, use 1way on last (num_lanes: 15 vs 16)
  - Exception: If different num_iters on two points, use 1way on both (happens inbetween)

Comments:
- Are other ways to structure processing, tried to keep to existing logic.
- If other ways/syntax preferred, just say so. Will rework to what fits best.

Testing:
- Compiled and ran with Linux/gcc, Linux/Clang, and Win10/VC++
- Live mmx-node improved CPU verify VDF times:
  - CPU: Intel 13th-gen, 8x P-cores (4.8GHz), 8x E-cores (3.5GHz)
  - VDF Speed (network): ~24.4 (3x VDF streams)
```
8x P-cores:   -4% (2.08 to 1.99 sec)
8x E-cores:  -43% (2.76 to 1.57 sec)
8x P + 8x E: -15% (1.26 to 1.06 sec)
```
- Live mmx-node improved CPU verify VDF times:
  - CPU: Simulated i3-1315U, 2x P-core (4.5GHz), 4x E-core (3.3GHz)
  - VDF Speed (network): ~23.7 (2x VDF streams)
```
Linux/gcc:   -22% (2.45 to 1.91 sec)
Linux/Clang: -24% (2.53 to 1.92 sec)
Win10/VC++:  -17% (2.49 to 2.05 sec)
```
- Notes:
  - Not a perfect simulate i3-1315U (power/cooling envelope, CPU cache, more).
  - Win11 may have better thread scheduler, or just more overhead for Win OS.
  - Not tested on AMD Zen CPU yet. Will when obtained one in the future.
  - Theoretically the i3-1315U could CPU verify a TimeLord of ~60 MH/s.
  - _DISCLAIMER (end-users): NOT an approval of i3-1315U devices for mmx-node._
  - _DISCLAIMER (end-users): Just a simulated experiment of what could be possible._