### PR TITLE
Use accelerated CPU SHA256 on ARM platforms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,6 +154,8 @@ add_library(mmx_iface SHARED
 	src/sha256_64_x8.cpp
 	src/sha256_ni.cpp
 	src/sha256_ni_rec.cpp
+	src/sha256_arm.cpp
+	src/sha256_arm_rec.cpp
 	src/sha512.cpp
 	src/hmac_sha512.cpp
 	src/wordlist_en.cpp
@@ -261,6 +263,12 @@ else()
 		set_source_files_properties(src/sha256_ni.cpp PROPERTIES COMPILE_FLAGS "-msse4.2 -msha")
 		set_source_files_properties(src/sha256_ni_rec.cpp PROPERTIES COMPILE_FLAGS "-msse4.2 -msha")
 		set_source_files_properties(src/sha256_avx2.cpp PROPERTIES COMPILE_FLAGS "-mavx2")
+	endif()
+
+	if(${CMAKE_HOST_SYSTEM_PROCESSOR} STREQUAL "aarch64")
+		message(STATUS "Enabling -march=armv8-a+crypto")
+		set_source_files_properties(src/sha256_arm.cpp PROPERTIES COMPILE_FLAGS "-march=armv8-a+crypto")
+		set_source_files_properties(src/sha256_arm_rec.cpp PROPERTIES COMPILE_FLAGS "-march=armv8-a+crypto")
 	endif()
 endif()
 

--- a/include/sha256_arm.h
+++ b/include/sha256_arm.h
@@ -1,0 +1,23 @@
+/*
+ * sha256_arm.h
+ *
+ *  Created on: Feb 21, 2024
+ *      Author: mad, voidxno
+ */
+
+#ifndef INCLUDE_SHA256_ARM_H_
+#define INCLUDE_SHA256_ARM_H_
+
+#include <cstdint>
+
+void sha256_arm(uint8_t* out, const uint8_t* in, const uint64_t length);
+
+void recursive_sha256_arm(uint8_t* hash, const uint64_t num_iters);
+
+void recursive_sha256_arm_x2(uint8_t* hash, const uint64_t num_iters);
+
+bool sha256_arm_available();
+
+
+
+#endif /* INCLUDE_SHA256_ARM_H_ */

--- a/src/TimeLord.cpp
+++ b/src/TimeLord.cpp
@@ -12,6 +12,7 @@
 #include <vnx/vnx.h>
 
 #include <sha256_ni.h>
+#include <sha256_arm.h>
 
 
 namespace mmx {
@@ -387,10 +388,13 @@ void TimeLord::vdf_loop(vdf_point_t point)
 hash_t TimeLord::compute(const hash_t& input, const uint64_t num_iters)
 {
 	static bool have_sha_ni = sha256_ni_available();
+	static bool have_sha_arm = sha256_arm_available();
 
 	hash_t hash = input;
 	if(have_sha_ni) {
 		recursive_sha256_ni(hash.data(), num_iters);
+	} else if(have_sha_arm) {
+		recursive_sha256_arm(hash.data(), num_iters);
 	} else {
 		for(uint64_t i = 0; i < num_iters; ++i) {
 			hash = hash_t(hash.bytes);

--- a/src/hash_t.cpp
+++ b/src/hash_t.cpp
@@ -11,6 +11,7 @@
 #include <bls.hpp>
 #include <sodium.h>
 #include <sha256_ni.h>
+#include <sha256_arm.h>
 
 
 namespace mmx {
@@ -18,8 +19,11 @@ namespace mmx {
 hash_t::hash_t(const void* data, const size_t num_bytes)
 {
 	static bool have_sha_ni = sha256_ni_available();
+	static bool have_sha_arm = sha256_arm_available();
 	if(have_sha_ni) {
 		sha256_ni(bytes.data(), (const uint8_t*)data, num_bytes);
+	} else if(have_sha_arm) {
+		sha256_arm(bytes.data(), (const uint8_t*)data, num_bytes);
 	} else {
 		bls::Util::Hash256(bytes.data(), (const uint8_t*)data, num_bytes);
 	}

--- a/src/mmx_node.cpp
+++ b/src/mmx_node.cpp
@@ -72,7 +72,9 @@ int main(int argc, char** argv)
 
 	vnx::log_info() << "AVX2 support:   " << (avx2_available() ? "yes" : "no");
 	vnx::log_info() << "SHA-NI support: " << (sha256_ni_available() ? "yes" : "no");
+#ifdef __aarch64__
 	vnx::log_info() << "ARM-SHA2 support: " << (sha256_arm_available() ? "yes" : "no");
+#endif // __aarch64__
 
 	if(with_farmer) {
 		with_wallet = true;

--- a/src/mmx_node.cpp
+++ b/src/mmx_node.cpp
@@ -16,6 +16,7 @@
 #include <mmx/secp256k1.hpp>
 #include <mmx/utils.h>
 #include <sha256_ni.h>
+#include <sha256_arm.h>
 #include <sha256_avx2.h>
 
 #include <vnx/vnx.h>
@@ -71,6 +72,7 @@ int main(int argc, char** argv)
 
 	vnx::log_info() << "AVX2 support:   " << (avx2_available() ? "yes" : "no");
 	vnx::log_info() << "SHA-NI support: " << (sha256_ni_available() ? "yes" : "no");
+	vnx::log_info() << "ARM-SHA2 support: " << (sha256_arm_available() ? "yes" : "no");
 
 	if(with_farmer) {
 		with_wallet = true;

--- a/src/mmx_timelord.cpp
+++ b/src/mmx_timelord.cpp
@@ -44,7 +44,9 @@ int main(int argc, char** argv)
 	vnx::read_config("endpoint", endpoint);
 
 	vnx::log_info() << "SHA-NI support: " << (sha256_ni_available() ? "yes" : "no");
+#ifdef __aarch64__
 	vnx::log_info() << "ARM-SHA2 support: " << (sha256_arm_available() ? "yes" : "no");
+#endif // __aarch64__
 
 	vnx::Handle<vnx::Proxy> proxy = new vnx::Proxy("Proxy", vnx::Endpoint::from_url(node_url));
 	proxy->forward_list = {"Node", "Wallet"};

--- a/src/mmx_timelord.cpp
+++ b/src/mmx_timelord.cpp
@@ -7,6 +7,7 @@
 
 #include <mmx/TimeLord.h>
 #include <sha256_ni.h>
+#include <sha256_arm.h>
 
 #include <vnx/vnx.h>
 #include <vnx/Proxy.h>
@@ -43,6 +44,7 @@ int main(int argc, char** argv)
 	vnx::read_config("endpoint", endpoint);
 
 	vnx::log_info() << "SHA-NI support: " << (sha256_ni_available() ? "yes" : "no");
+	vnx::log_info() << "ARM-SHA2 support: " << (sha256_arm_available() ? "yes" : "no");
 
 	vnx::Handle<vnx::Proxy> proxy = new vnx::Proxy("Proxy", vnx::Endpoint::from_url(node_url));
 	proxy->forward_list = {"Node", "Wallet"};

--- a/src/sha256_64_x8.cpp
+++ b/src/sha256_64_x8.cpp
@@ -7,6 +7,7 @@
 
 #include <sha256_avx2.h>
 #include <sha256_ni.h>
+#include <sha256_arm.h>
 #include <mmx/hash_t.hpp>
 
 
@@ -14,10 +15,15 @@ void sha256_64_x8(uint8_t* out, uint8_t* in, const uint64_t length)
 {
 	static bool have_avx2 = avx2_available();
 	static bool have_sha_ni = sha256_ni_available();
+	static bool have_sha_arm = sha256_arm_available();
 
 	if(have_sha_ni) {
 		for(int i = 0; i < 8; ++i) {
 			sha256_ni(out + i * 32, in + i * 64, length);
+		}
+	} else if(have_sha_arm) {
+		for(int i = 0; i < 8; ++i) {
+			sha256_arm(out + i * 32, in + i * 64, length);
 		}
 	} else if(have_avx2) {
 		sha256_avx2_64_x8(out, in, length);

--- a/src/sha256_arm.cpp
+++ b/src/sha256_arm.cpp
@@ -1,0 +1,252 @@
+/*
+ * sha256_arm.cpp
+ *
+ *  Created on: Feb 21, 2024
+ *      Author: mad, voidxno
+ */
+
+#include <sha256_arm.h>
+
+#include <cstring>
+#include <stdexcept>
+
+#if defined(__aarch64__)
+
+#include <sys/auxv.h>
+#include <arm_neon.h>
+
+static const uint32_t K64[] = {
+	0x428A2F98, 0x71374491, 0xB5C0FBCF, 0xE9B5DBA5,
+	0x3956C25B, 0x59F111F1, 0x923F82A4, 0xAB1C5ED5,
+	0xD807AA98, 0x12835B01, 0x243185BE, 0x550C7DC3,
+	0x72BE5D74, 0x80DEB1FE, 0x9BDC06A7, 0xC19BF174,
+	0xE49B69C1, 0xEFBE4786, 0x0FC19DC6, 0x240CA1CC,
+	0x2DE92C6F, 0x4A7484AA, 0x5CB0A9DC, 0x76F988DA,
+	0x983E5152, 0xA831C66D, 0xB00327C8, 0xBF597FC7,
+	0xC6E00BF3, 0xD5A79147, 0x06CA6351, 0x14292967,
+	0x27B70A85, 0x2E1B2138, 0x4D2C6DFC, 0x53380D13,
+	0x650A7354, 0x766A0ABB, 0x81C2C92E, 0x92722C85,
+	0xA2BFE8A1, 0xA81A664B, 0xC24B8B70, 0xC76C51A3,
+	0xD192E819, 0xD6990624, 0xF40E3585, 0x106AA070,
+	0x19A4C116, 0x1E376C08, 0x2748774C, 0x34B0BCB5,
+	0x391C0CB3, 0x4ED8AA4A, 0x5B9CCA4F, 0x682E6FF3,
+	0x748F82EE, 0x78A5636F, 0x84C87814, 0x8CC70208,
+	0x90BEFFFA, 0xA4506CEB, 0xBEF9A3F7, 0xC67178F2,
+};
+
+inline uint32_t bswap_32(const uint32_t val) {
+	return ((val & 0xFF) << 24) | ((val & 0xFF00) << 8) | ((val & 0xFF0000) >> 8) | ((val & 0xFF000000) >> 24);
+}
+
+inline uint64_t bswap_64(const uint64_t val) {
+	return (uint64_t(bswap_32(val)) << 32) | bswap_32(val >> 32);
+}
+
+static void compress_digest(uint32_t* state, const uint8_t* input, size_t blocks)
+{
+	const uint8_t* input_mm = input;
+
+	// Load initial values
+	uint32x4_t STATE0 = vld1q_u32(&state[0]);
+	uint32x4_t STATE1 = vld1q_u32(&state[4]);
+
+	while(blocks > 0)
+	{
+		// Save current state
+		const uint32x4_t ABCD_SAVE = STATE0;
+		const uint32x4_t EFGH_SAVE = STATE1;
+
+		uint32x4_t MSGV;
+		uint32x4_t STATEV;
+
+		uint32x4_t MSGTMP0 = vld1q_u32((const uint32_t*)(&input_mm[0]));
+		uint32x4_t MSGTMP1 = vld1q_u32((const uint32_t*)(&input_mm[16]));
+		uint32x4_t MSGTMP2 = vld1q_u32((const uint32_t*)(&input_mm[32]));
+		uint32x4_t MSGTMP3 = vld1q_u32((const uint32_t*)(&input_mm[48]));
+
+		MSGTMP0 = vreinterpretq_u32_u8(vrev32q_u8(vreinterpretq_u8_u32(MSGTMP0)));
+		MSGTMP1 = vreinterpretq_u32_u8(vrev32q_u8(vreinterpretq_u8_u32(MSGTMP1)));
+		MSGTMP2 = vreinterpretq_u32_u8(vrev32q_u8(vreinterpretq_u8_u32(MSGTMP2)));
+		MSGTMP3 = vreinterpretq_u32_u8(vrev32q_u8(vreinterpretq_u8_u32(MSGTMP3)));
+
+		// Rounds 0-3
+		MSGV = vaddq_u32(MSGTMP0, vld1q_u32(&K64[0]));
+		STATEV = STATE0;
+		STATE0 = vsha256hq_u32(STATE0, STATE1, MSGV);
+		STATE1 = vsha256h2q_u32(STATE1, STATEV, MSGV);
+		MSGTMP0 = vsha256su0q_u32(MSGTMP0, MSGTMP1);
+
+		// Rounds 4-7
+		MSGV = vaddq_u32(MSGTMP1, vld1q_u32(&K64[4]));
+		STATEV = STATE0;
+		STATE0 = vsha256hq_u32(STATE0, STATE1, MSGV);
+		STATE1 = vsha256h2q_u32(STATE1, STATEV, MSGV);
+		MSGTMP0 = vsha256su1q_u32(MSGTMP0, MSGTMP2, MSGTMP3);
+		MSGTMP1 = vsha256su0q_u32(MSGTMP1, MSGTMP2);
+
+		// Rounds 8-11
+		MSGV = vaddq_u32(MSGTMP2, vld1q_u32(&K64[8]));
+		STATEV = STATE0;
+		STATE0 = vsha256hq_u32(STATE0, STATE1, MSGV);
+		STATE1 = vsha256h2q_u32(STATE1, STATEV, MSGV);
+		MSGTMP1 = vsha256su1q_u32(MSGTMP1, MSGTMP3, MSGTMP0);
+		MSGTMP2 = vsha256su0q_u32(MSGTMP2, MSGTMP3);
+
+		// Rounds 12-15
+		MSGV = vaddq_u32(MSGTMP3, vld1q_u32(&K64[12]));
+		STATEV = STATE0;
+		STATE0 = vsha256hq_u32(STATE0, STATE1, MSGV);
+		STATE1 = vsha256h2q_u32(STATE1, STATEV, MSGV);
+		MSGTMP2 = vsha256su1q_u32(MSGTMP2, MSGTMP0, MSGTMP1);
+		MSGTMP3 = vsha256su0q_u32(MSGTMP3, MSGTMP0);
+
+		// Rounds 16-19
+		MSGV = vaddq_u32(MSGTMP0, vld1q_u32(&K64[16]));
+		STATEV = STATE0;
+		STATE0 = vsha256hq_u32(STATE0, STATE1, MSGV);
+		STATE1 = vsha256h2q_u32(STATE1, STATEV, MSGV);
+		MSGTMP3 = vsha256su1q_u32(MSGTMP3, MSGTMP1, MSGTMP2);
+		MSGTMP0 = vsha256su0q_u32(MSGTMP0, MSGTMP1);
+
+		// Rounds 20-23
+		MSGV = vaddq_u32(MSGTMP1, vld1q_u32(&K64[20]));
+		STATEV = STATE0;
+		STATE0 = vsha256hq_u32(STATE0, STATE1, MSGV);
+		STATE1 = vsha256h2q_u32(STATE1, STATEV, MSGV);
+		MSGTMP0 = vsha256su1q_u32(MSGTMP0, MSGTMP2, MSGTMP3);
+		MSGTMP1 = vsha256su0q_u32(MSGTMP1, MSGTMP2);
+
+		// Rounds 24-27
+		MSGV = vaddq_u32(MSGTMP2, vld1q_u32(&K64[24]));
+		STATEV = STATE0;
+		STATE0 = vsha256hq_u32(STATE0, STATE1, MSGV);
+		STATE1 = vsha256h2q_u32(STATE1, STATEV, MSGV);
+		MSGTMP1 = vsha256su1q_u32(MSGTMP1, MSGTMP3, MSGTMP0);
+		MSGTMP2 = vsha256su0q_u32(MSGTMP2, MSGTMP3);
+
+		// Rounds 28-31
+		MSGV = vaddq_u32(MSGTMP3, vld1q_u32(&K64[28]));
+		STATEV = STATE0;
+		STATE0 = vsha256hq_u32(STATE0, STATE1, MSGV);
+		STATE1 = vsha256h2q_u32(STATE1, STATEV, MSGV);
+		MSGTMP2 = vsha256su1q_u32(MSGTMP2, MSGTMP0, MSGTMP1);
+		MSGTMP3 = vsha256su0q_u32(MSGTMP3, MSGTMP0);
+
+		// Rounds 32-35
+		MSGV = vaddq_u32(MSGTMP0, vld1q_u32(&K64[32]));
+		STATEV = STATE0;
+		STATE0 = vsha256hq_u32(STATE0, STATE1, MSGV);
+		STATE1 = vsha256h2q_u32(STATE1, STATEV, MSGV);
+		MSGTMP3 = vsha256su1q_u32(MSGTMP3, MSGTMP1, MSGTMP2);
+		MSGTMP0 = vsha256su0q_u32(MSGTMP0, MSGTMP1);
+
+		// Rounds 36-39
+		MSGV = vaddq_u32(MSGTMP1, vld1q_u32(&K64[36]));
+		STATEV = STATE0;
+		STATE0 = vsha256hq_u32(STATE0, STATE1, MSGV);
+		STATE1 = vsha256h2q_u32(STATE1, STATEV, MSGV);
+		MSGTMP0 = vsha256su1q_u32(MSGTMP0, MSGTMP2, MSGTMP3);
+		MSGTMP1 = vsha256su0q_u32(MSGTMP1, MSGTMP2);
+
+		// Rounds 40-43
+		MSGV = vaddq_u32(MSGTMP2, vld1q_u32(&K64[40]));
+		STATEV = STATE0;
+		STATE0 = vsha256hq_u32(STATE0, STATE1, MSGV);
+		STATE1 = vsha256h2q_u32(STATE1, STATEV, MSGV);
+		MSGTMP1 = vsha256su1q_u32(MSGTMP1, MSGTMP3, MSGTMP0);
+		MSGTMP2 = vsha256su0q_u32(MSGTMP2, MSGTMP3);
+
+		// Rounds 44-47
+		MSGV = vaddq_u32(MSGTMP3, vld1q_u32(&K64[44]));
+		STATEV = STATE0;
+		STATE0 = vsha256hq_u32(STATE0, STATE1, MSGV);
+		STATE1 = vsha256h2q_u32(STATE1, STATEV, MSGV);
+		MSGTMP2 = vsha256su1q_u32(MSGTMP2, MSGTMP0, MSGTMP1);
+		MSGTMP3 = vsha256su0q_u32(MSGTMP3, MSGTMP0);
+
+		// Rounds 48-51
+		MSGV = vaddq_u32(MSGTMP0, vld1q_u32(&K64[48]));
+		STATEV = STATE0;
+		STATE0 = vsha256hq_u32(STATE0, STATE1, MSGV);
+		STATE1 = vsha256h2q_u32(STATE1, STATEV, MSGV);
+		MSGTMP3 = vsha256su1q_u32(MSGTMP3, MSGTMP1, MSGTMP2);
+
+		// Rounds 52-55
+		MSGV = vaddq_u32(MSGTMP1, vld1q_u32(&K64[52]));
+		STATEV = STATE0;
+		STATE0 = vsha256hq_u32(STATE0, STATE1, MSGV);
+		STATE1 = vsha256h2q_u32(STATE1, STATEV, MSGV);
+
+		// Rounds 56-59
+		MSGV = vaddq_u32(MSGTMP2, vld1q_u32(&K64[56]));
+		STATEV = STATE0;
+		STATE0 = vsha256hq_u32(STATE0, STATE1, MSGV);
+		STATE1 = vsha256h2q_u32(STATE1, STATEV, MSGV);
+
+		// Rounds 60-63
+		MSGV = vaddq_u32(MSGTMP3, vld1q_u32(&K64[60]));
+		STATEV = STATE0;
+		STATE0 = vsha256hq_u32(STATE0, STATE1, MSGV);
+		STATE1 = vsha256h2q_u32(STATE1, STATEV, MSGV);
+
+		// Add values back to state
+		STATE0 = vaddq_u32(STATE0, ABCD_SAVE);
+		STATE1 = vaddq_u32(STATE1, EFGH_SAVE);
+
+		input_mm = &input_mm[64];
+		blocks--;
+	}
+
+ // Save state
+ vst1q_u32(&state[0], STATE0);
+ vst1q_u32(&state[4], STATE1);
+}
+
+void sha256_arm(uint8_t* out, const uint8_t* in, const uint64_t length)
+{
+	uint32_t state[] = {0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19};
+
+	const auto num_blocks = length / 64;
+	if(num_blocks) {
+		compress_digest(state, in, num_blocks);
+	}
+	const auto remain = length % 64;
+	const auto final_blocks = (remain + 9 + 63) / 64;
+	const uint64_t num_bits = bswap_64(length * 8);
+	const uint8_t end_bit = 0x80;
+
+	uint8_t last[128] = {};
+	::memcpy(last, in + num_blocks * 64, remain);
+	::memset(last + remain, 0, sizeof(last) - remain);
+	::memcpy(last + remain, &end_bit, 1);
+	::memcpy(last + final_blocks * 64 - 8, &num_bits, 8);
+
+	compress_digest(state, last, final_blocks);
+
+	for(int k = 0; k < 8; ++k) {
+		state[k] = bswap_32(state[k]);
+	}
+	::memcpy(out, state, 32);
+}
+
+bool sha256_arm_available()
+{
+	// ARM Cryptography Extensions (SHA256 feature)
+	// ID_AA64ISAR0_EL1 feature register, bits 15-12 (SHA2)
+
+	// user space detect through getauxval()
+	return (getauxval(AT_HWCAP) & HWCAP_SHA2) ? true : false;
+}
+
+#else // __aarch64__
+
+void sha256_arm(uint8_t* out, const uint8_t* in, const uint64_t length) {
+	throw std::logic_error("sha256_arm() not available");
+}
+
+bool sha256_arm_available() {
+	return false;
+}
+
+#endif // __aarch64__
+

--- a/src/sha256_arm_rec.cpp
+++ b/src/sha256_arm_rec.cpp
@@ -1,0 +1,393 @@
+/*
+ * sha256_arm_rec.cpp
+ *
+ *  Created on: Feb 21, 2024
+ *      Author: mad, voidxno
+ */
+
+// prerequisite: length is 32 bytes (recursive sha256)
+// prerequisite: length is 64 bytes, 2x 32bytes (_x2)
+// optimization: https://github.com/voidxno/fast-recursive-sha256
+
+#include <sha256_arm.h>
+
+#include <cstring>
+#include <stdexcept>
+
+#if defined(__aarch64__)
+
+#include <arm_neon.h>
+
+void recursive_sha256_arm(uint8_t* hash, const uint64_t num_iters)
+{
+	if(num_iters <= 0) {
+		return;
+	}
+
+	static const uint32_t K64[64] = {
+		0x428A2F98, 0x71374491, 0xB5C0FBCF, 0xE9B5DBA5,
+		0x3956C25B, 0x59F111F1, 0x923F82A4, 0xAB1C5ED5,
+		0xD807AA98, 0x12835B01, 0x243185BE, 0x550C7DC3,
+		0x72BE5D74, 0x80DEB1FE, 0x9BDC06A7, 0xC19BF174,
+		0xE49B69C1, 0xEFBE4786, 0x0FC19DC6, 0x240CA1CC,
+		0x2DE92C6F, 0x4A7484AA, 0x5CB0A9DC, 0x76F988DA,
+		0x983E5152, 0xA831C66D, 0xB00327C8, 0xBF597FC7,
+		0xC6E00BF3, 0xD5A79147, 0x06CA6351, 0x14292967,
+		0x27B70A85, 0x2E1B2138, 0x4D2C6DFC, 0x53380D13,
+		0x650A7354, 0x766A0ABB, 0x81C2C92E, 0x92722C85,
+		0xA2BFE8A1, 0xA81A664B, 0xC24B8B70, 0xC76C51A3,
+		0xD192E819, 0xD6990624, 0xF40E3585, 0x106AA070,
+		0x19A4C116, 0x1E376C08, 0x2748774C, 0x34B0BCB5,
+		0x391C0CB3, 0x4ED8AA4A, 0x5B9CCA4F, 0x682E6FF3,
+		0x748F82EE, 0x78A5636F, 0x84C87814, 0x8CC70208,
+		0x90BEFFFA, 0xA4506CEB, 0xBEF9A3F7, 0xC67178F2
+	};
+
+	// init values
+	static const uint32_t abcdinit[4] = {0x6A09E667,0xBB67AE85,0x3C6EF372,0xA54FF53A};
+	static const uint32_t efghinit[4] = {0x510E527F,0x9B05688C,0x1F83D9AB,0x5BE0CD19};
+	const uint32x4_t ABCD_INIT = vld1q_u32(&abcdinit[0]);
+	const uint32x4_t EFGH_INIT = vld1q_u32(&efghinit[0]);
+
+	// pre-calc/cache padding
+	static const uint32_t hpad0cache[4] = {0x80000000,0x00000000,0x00000000,0x00000000};
+	static const uint32_t hpad1cache[4] = {0x00000000,0x00000000,0x00000000,0x00000100};
+	const uint32x4_t HPAD0_CACHE = vld1q_u32(&hpad0cache[0]);
+	const uint32x4_t HPAD1_CACHE = vld1q_u32(&hpad1cache[0]);
+
+	uint32x4_t STATE0;
+	uint32x4_t STATE1;
+	uint32x4_t STATEV;
+	uint32x4_t MSGV;
+	uint32x4_t MSGTMP0;
+	uint32x4_t MSGTMP1;
+	uint32x4_t MSGTMP2;
+	uint32x4_t MSGTMP3;
+
+	// init/shuffle hash
+	uint32x4_t HASH0_SAVE = vld1q_u32((const uint32_t*)(&hash[0]));
+	uint32x4_t HASH1_SAVE = vld1q_u32((const uint32_t*)(&hash[16]));
+	HASH0_SAVE = vreinterpretq_u32_u8(vrev32q_u8(vreinterpretq_u8_u32(HASH0_SAVE)));
+	HASH1_SAVE = vreinterpretq_u32_u8(vrev32q_u8(vreinterpretq_u8_u32(HASH1_SAVE)));
+
+	for(uint64_t i = 0; i < num_iters; ++i) {
+
+		// init state
+		STATE0 = ABCD_INIT;
+		STATE1 = EFGH_INIT;
+
+		// rounds 0-3
+		MSGV = vaddq_u32(HASH0_SAVE,vld1q_u32(&K64[0]));
+		STATEV = STATE0;
+		STATE0 = vsha256hq_u32(STATE0,STATE1,MSGV);
+		STATE1 = vsha256h2q_u32(STATE1,STATEV,MSGV);
+		MSGTMP0 = vsha256su0q_u32(HASH0_SAVE,HASH1_SAVE);
+
+		// rounds 4-7
+		MSGV = vaddq_u32(HASH1_SAVE,vld1q_u32(&K64[4]));
+		STATEV = STATE0;
+		STATE0 = vsha256hq_u32(STATE0,STATE1,MSGV);
+		STATE1 = vsha256h2q_u32(STATE1,STATEV,MSGV);
+		MSGTMP0 = vsha256su1q_u32(MSGTMP0,HPAD0_CACHE,HPAD1_CACHE);
+		MSGTMP1 = vsha256su0q_u32(HASH1_SAVE,HPAD0_CACHE);
+
+		// rounds 8-11
+		MSGV = vaddq_u32(HPAD0_CACHE,vld1q_u32(&K64[8]));
+		STATEV = STATE0;
+		STATE0 = vsha256hq_u32(STATE0,STATE1,MSGV);
+		STATE1 = vsha256h2q_u32(STATE1,STATEV,MSGV);
+		MSGTMP1 = vsha256su1q_u32(MSGTMP1,HPAD1_CACHE,MSGTMP0);
+		MSGTMP2 = HPAD0_CACHE;
+
+		// rounds 12-15
+		MSGV = vaddq_u32(HPAD1_CACHE,vld1q_u32(&K64[12]));
+		STATEV = STATE0;
+		STATE0 = vsha256hq_u32(STATE0,STATE1,MSGV);
+		STATE1 = vsha256h2q_u32(STATE1,STATEV,MSGV);
+		MSGTMP2 = vsha256su1q_u32(MSGTMP2,MSGTMP0,MSGTMP1);
+		MSGTMP3 = vsha256su0q_u32(HPAD1_CACHE,MSGTMP0);
+
+#define SHA256ROUND( \
+msgv, msgtmp0, msgtmp1, msgtmp2, msgtmp3, statev, state0, state1, kvalue) \
+	msgv = vaddq_u32(msgtmp0,vld1q_u32(kvalue)); \
+	statev = state0; \
+	state0 = vsha256hq_u32(state0,state1,msgv); \
+	state1 = vsha256h2q_u32(state1,statev,msgv); \
+	msgtmp3 = vsha256su1q_u32(msgtmp3,msgtmp1,msgtmp2); \
+	msgtmp0 = vsha256su0q_u32(msgtmp0,msgtmp1);
+
+		// rounds 16-19, 20-23, 24-27, 28-31
+		SHA256ROUND(MSGV,MSGTMP0,MSGTMP1,MSGTMP2,MSGTMP3,STATEV,STATE0,STATE1,&K64[16]);
+		SHA256ROUND(MSGV,MSGTMP1,MSGTMP2,MSGTMP3,MSGTMP0,STATEV,STATE0,STATE1,&K64[20]);
+		SHA256ROUND(MSGV,MSGTMP2,MSGTMP3,MSGTMP0,MSGTMP1,STATEV,STATE0,STATE1,&K64[24]);
+		SHA256ROUND(MSGV,MSGTMP3,MSGTMP0,MSGTMP1,MSGTMP2,STATEV,STATE0,STATE1,&K64[28]);
+
+		// rounds 32-35, 36-39, 40-43, 44-47
+		SHA256ROUND(MSGV,MSGTMP0,MSGTMP1,MSGTMP2,MSGTMP3,STATEV,STATE0,STATE1,&K64[32]);
+		SHA256ROUND(MSGV,MSGTMP1,MSGTMP2,MSGTMP3,MSGTMP0,STATEV,STATE0,STATE1,&K64[36]);
+		SHA256ROUND(MSGV,MSGTMP2,MSGTMP3,MSGTMP0,MSGTMP1,STATEV,STATE0,STATE1,&K64[40]);
+		SHA256ROUND(MSGV,MSGTMP3,MSGTMP0,MSGTMP1,MSGTMP2,STATEV,STATE0,STATE1,&K64[44]);
+
+		// rounds 48-51
+		MSGV = vaddq_u32(MSGTMP0,vld1q_u32(&K64[48]));
+		STATEV = STATE0;
+		STATE0 = vsha256hq_u32(STATE0,STATE1,MSGV);
+		STATE1 = vsha256h2q_u32(STATE1,STATEV,MSGV);
+		MSGTMP3 = vsha256su1q_u32(MSGTMP3,MSGTMP1,MSGTMP2);
+
+		// rounds 52-55
+		MSGV = vaddq_u32(MSGTMP1,vld1q_u32(&K64[52]));
+		STATEV = STATE0;
+		STATE0 = vsha256hq_u32(STATE0,STATE1,MSGV);
+		STATE1 = vsha256h2q_u32(STATE1,STATEV,MSGV);
+
+		// rounds 56-59
+		MSGV = vaddq_u32(MSGTMP2,vld1q_u32(&K64[56]));
+		STATEV = STATE0;
+		STATE0 = vsha256hq_u32(STATE0,STATE1,MSGV);
+		STATE1 = vsha256h2q_u32(STATE1,STATEV,MSGV);
+
+		// rounds 60-63
+		MSGV = vaddq_u32(MSGTMP3,vld1q_u32(&K64[60]));
+		STATEV = STATE0;
+		STATE0 = vsha256hq_u32(STATE0,STATE1,MSGV);
+		STATE1 = vsha256h2q_u32(STATE1,STATEV,MSGV);
+
+		// add to state
+		HASH0_SAVE = vaddq_u32(STATE0,ABCD_INIT);
+		HASH1_SAVE = vaddq_u32(STATE1,EFGH_INIT);
+	}
+
+	// shuffle/return hash
+	HASH0_SAVE = vreinterpretq_u32_u8(vrev32q_u8(vreinterpretq_u8_u32(HASH0_SAVE)));
+	HASH1_SAVE = vreinterpretq_u32_u8(vrev32q_u8(vreinterpretq_u8_u32(HASH1_SAVE)));
+	vst1q_u32((uint32_t*)(&hash[0]),HASH0_SAVE);
+	vst1q_u32((uint32_t*)(&hash[16]),HASH1_SAVE);
+}
+
+void recursive_sha256_arm_x2(uint8_t* hash, const uint64_t num_iters)
+{
+	if(num_iters <= 0) {
+		return;
+	}
+
+	static const uint32_t K64[64] = {
+		0x428A2F98, 0x71374491, 0xB5C0FBCF, 0xE9B5DBA5,
+		0x3956C25B, 0x59F111F1, 0x923F82A4, 0xAB1C5ED5,
+		0xD807AA98, 0x12835B01, 0x243185BE, 0x550C7DC3,
+		0x72BE5D74, 0x80DEB1FE, 0x9BDC06A7, 0xC19BF174,
+		0xE49B69C1, 0xEFBE4786, 0x0FC19DC6, 0x240CA1CC,
+		0x2DE92C6F, 0x4A7484AA, 0x5CB0A9DC, 0x76F988DA,
+		0x983E5152, 0xA831C66D, 0xB00327C8, 0xBF597FC7,
+		0xC6E00BF3, 0xD5A79147, 0x06CA6351, 0x14292967,
+		0x27B70A85, 0x2E1B2138, 0x4D2C6DFC, 0x53380D13,
+		0x650A7354, 0x766A0ABB, 0x81C2C92E, 0x92722C85,
+		0xA2BFE8A1, 0xA81A664B, 0xC24B8B70, 0xC76C51A3,
+		0xD192E819, 0xD6990624, 0xF40E3585, 0x106AA070,
+		0x19A4C116, 0x1E376C08, 0x2748774C, 0x34B0BCB5,
+		0x391C0CB3, 0x4ED8AA4A, 0x5B9CCA4F, 0x682E6FF3,
+		0x748F82EE, 0x78A5636F, 0x84C87814, 0x8CC70208,
+		0x90BEFFFA, 0xA4506CEB, 0xBEF9A3F7, 0xC67178F2
+	};
+
+	// init values
+	static const uint32_t abcdinit[4] = {0x6A09E667,0xBB67AE85,0x3C6EF372,0xA54FF53A};
+	static const uint32_t efghinit[4] = {0x510E527F,0x9B05688C,0x1F83D9AB,0x5BE0CD19};
+	const uint32x4_t ABCD_INIT = vld1q_u32(&abcdinit[0]);
+	const uint32x4_t EFGH_INIT = vld1q_u32(&efghinit[0]);
+
+	// pre-calc/cache padding
+	static const uint32_t hpad0cache[4] = {0x80000000,0x00000000,0x00000000,0x00000000};
+	static const uint32_t hpad1cache[4] = {0x00000000,0x00000000,0x00000000,0x00000100};
+	const uint32x4_t HPAD0_CACHE = vld1q_u32(&hpad0cache[0]);
+	const uint32x4_t HPAD1_CACHE = vld1q_u32(&hpad1cache[0]);
+
+	uint32x4_t STATE0_P1;
+	uint32x4_t STATE1_P1;
+	uint32x4_t STATEV_P1;
+	uint32x4_t MSGV_P1;
+	uint32x4_t MSGTMP0_P1;
+	uint32x4_t MSGTMP1_P1;
+	uint32x4_t MSGTMP2_P1;
+	uint32x4_t MSGTMP3_P1;
+	uint32x4_t STATE0_P2;
+	uint32x4_t STATE1_P2;
+	uint32x4_t STATEV_P2;
+	uint32x4_t MSGV_P2;
+	uint32x4_t MSGTMP0_P2;
+	uint32x4_t MSGTMP1_P2;
+	uint32x4_t MSGTMP2_P2;
+	uint32x4_t MSGTMP3_P2;
+
+	// init/shuffle hash
+	uint32x4_t HASH0_SAVE_P1 = vld1q_u32((const uint32_t*)(&hash[0]));
+	uint32x4_t HASH1_SAVE_P1 = vld1q_u32((const uint32_t*)(&hash[16]));
+	uint32x4_t HASH0_SAVE_P2 = vld1q_u32((const uint32_t*)(&hash[32]));
+	uint32x4_t HASH1_SAVE_P2 = vld1q_u32((const uint32_t*)(&hash[48]));
+	HASH0_SAVE_P1 = vreinterpretq_u32_u8(vrev32q_u8(vreinterpretq_u8_u32(HASH0_SAVE_P1)));
+	HASH1_SAVE_P1 = vreinterpretq_u32_u8(vrev32q_u8(vreinterpretq_u8_u32(HASH1_SAVE_P1)));
+	HASH0_SAVE_P2 = vreinterpretq_u32_u8(vrev32q_u8(vreinterpretq_u8_u32(HASH0_SAVE_P2)));
+	HASH1_SAVE_P2 = vreinterpretq_u32_u8(vrev32q_u8(vreinterpretq_u8_u32(HASH1_SAVE_P2)));
+
+	for(uint64_t i = 0; i < num_iters; ++i) {
+
+		// init state
+		STATE0_P1 = ABCD_INIT;
+		STATE0_P2 = ABCD_INIT;
+		STATE1_P1 = EFGH_INIT;
+		STATE1_P2 = EFGH_INIT;
+
+		// rounds 0-3
+		MSGV_P1 = vaddq_u32(HASH0_SAVE_P1,vld1q_u32(&K64[0]));
+		MSGV_P2 = vaddq_u32(HASH0_SAVE_P2,vld1q_u32(&K64[0]));
+		STATEV_P1 = STATE0_P1;
+		STATEV_P2 = STATE0_P2;
+		STATE0_P1 = vsha256hq_u32(STATE0_P1,STATE1_P1,MSGV_P1);
+		STATE0_P2 = vsha256hq_u32(STATE0_P2,STATE1_P2,MSGV_P2);
+		STATE1_P1 = vsha256h2q_u32(STATE1_P1,STATEV_P1,MSGV_P1);
+		STATE1_P2 = vsha256h2q_u32(STATE1_P2,STATEV_P2,MSGV_P2);
+		MSGTMP0_P1 = vsha256su0q_u32(HASH0_SAVE_P1,HASH1_SAVE_P1);
+		MSGTMP0_P2 = vsha256su0q_u32(HASH0_SAVE_P2,HASH1_SAVE_P2);
+
+		// rounds 4-7
+		MSGV_P1 = vaddq_u32(HASH1_SAVE_P1,vld1q_u32(&K64[4]));
+		MSGV_P2 = vaddq_u32(HASH1_SAVE_P2,vld1q_u32(&K64[4]));
+		STATEV_P1 = STATE0_P1;
+		STATEV_P2 = STATE0_P2;
+		STATE0_P1 = vsha256hq_u32(STATE0_P1,STATE1_P1,MSGV_P1);
+		STATE0_P2 = vsha256hq_u32(STATE0_P2,STATE1_P2,MSGV_P2);
+		STATE1_P1 = vsha256h2q_u32(STATE1_P1,STATEV_P1,MSGV_P1);
+		STATE1_P2 = vsha256h2q_u32(STATE1_P2,STATEV_P2,MSGV_P2);
+		MSGTMP0_P1 = vsha256su1q_u32(MSGTMP0_P1,HPAD0_CACHE,HPAD1_CACHE);
+		MSGTMP0_P2 = vsha256su1q_u32(MSGTMP0_P2,HPAD0_CACHE,HPAD1_CACHE);
+		MSGTMP1_P1 = vsha256su0q_u32(HASH1_SAVE_P1,HPAD0_CACHE);
+		MSGTMP1_P2 = vsha256su0q_u32(HASH1_SAVE_P2,HPAD0_CACHE);
+
+		// rounds 8-11
+		MSGV_P1 = vaddq_u32(HPAD0_CACHE,vld1q_u32(&K64[8]));
+		MSGV_P2 = vaddq_u32(HPAD0_CACHE,vld1q_u32(&K64[8]));
+		STATEV_P1 = STATE0_P1;
+		STATEV_P2 = STATE0_P2;
+		STATE0_P1 = vsha256hq_u32(STATE0_P1,STATE1_P1,MSGV_P1);
+		STATE0_P2 = vsha256hq_u32(STATE0_P2,STATE1_P2,MSGV_P2);
+		STATE1_P1 = vsha256h2q_u32(STATE1_P1,STATEV_P1,MSGV_P1);
+		STATE1_P2 = vsha256h2q_u32(STATE1_P2,STATEV_P2,MSGV_P2);
+		MSGTMP1_P1 = vsha256su1q_u32(MSGTMP1_P1,HPAD1_CACHE,MSGTMP0_P1);
+		MSGTMP1_P2 = vsha256su1q_u32(MSGTMP1_P2,HPAD1_CACHE,MSGTMP0_P2);
+		MSGTMP2_P1 = HPAD0_CACHE;
+		MSGTMP2_P2 = HPAD0_CACHE;
+
+		// rounds 12-15
+		MSGV_P1 = vaddq_u32(HPAD1_CACHE,vld1q_u32(&K64[12]));
+		MSGV_P2 = vaddq_u32(HPAD1_CACHE,vld1q_u32(&K64[12]));
+		STATEV_P1 = STATE0_P1;
+		STATEV_P2 = STATE0_P2;
+		STATE0_P1 = vsha256hq_u32(STATE0_P1,STATE1_P1,MSGV_P1);
+		STATE0_P2 = vsha256hq_u32(STATE0_P2,STATE1_P2,MSGV_P2);
+		STATE1_P1 = vsha256h2q_u32(STATE1_P1,STATEV_P1,MSGV_P1);
+		STATE1_P2 = vsha256h2q_u32(STATE1_P2,STATEV_P2,MSGV_P2);
+		MSGTMP2_P1 = vsha256su1q_u32(MSGTMP2_P1,MSGTMP0_P1,MSGTMP1_P1);
+		MSGTMP2_P2 = vsha256su1q_u32(MSGTMP2_P2,MSGTMP0_P2,MSGTMP1_P2);
+		MSGTMP3_P1 = vsha256su0q_u32(HPAD1_CACHE,MSGTMP0_P1);
+		MSGTMP3_P2 = vsha256su0q_u32(HPAD1_CACHE,MSGTMP0_P2);
+
+#define SHA256ROUND_X2( \
+msgv_p1, msgtmp0_p1, msgtmp1_p1, msgtmp2_p1, msgtmp3_p1, statev_p1, state0_p1, state1_p1, \
+msgv_p2, msgtmp0_p2, msgtmp1_p2, msgtmp2_p2, msgtmp3_p2, statev_p2, state0_p2, state1_p2, kvalue) \
+	msgv_p1 = vaddq_u32(msgtmp0_p1,vld1q_u32(kvalue)); \
+	msgv_p2 = vaddq_u32(msgtmp0_p2,vld1q_u32(kvalue)); \
+	statev_p1 = state0_p1; \
+	statev_p2 = state0_p2; \
+	state0_p1 = vsha256hq_u32(state0_p1,state1_p1,msgv_p1); \
+	state0_p2 = vsha256hq_u32(state0_p2,state1_p2,msgv_p2); \
+	state1_p1 = vsha256h2q_u32(state1_p1,statev_p1,msgv_p1); \
+	state1_p2 = vsha256h2q_u32(state1_p2,statev_p2,msgv_p2); \
+	msgtmp3_p1 = vsha256su1q_u32(msgtmp3_p1,msgtmp1_p1,msgtmp2_p1); \
+	msgtmp3_p2 = vsha256su1q_u32(msgtmp3_p2,msgtmp1_p2,msgtmp2_p2); \
+	msgtmp0_p1 = vsha256su0q_u32(msgtmp0_p1,msgtmp1_p1); \
+	msgtmp0_p2 = vsha256su0q_u32(msgtmp0_p2,msgtmp1_p2);
+
+		// rounds 16-19, 20-23, 24-27, 28-31
+		SHA256ROUND_X2(MSGV_P1,MSGTMP0_P1,MSGTMP1_P1,MSGTMP2_P1,MSGTMP3_P1,STATEV_P1,STATE0_P1,STATE1_P1,MSGV_P2,MSGTMP0_P2,MSGTMP1_P2,MSGTMP2_P2,MSGTMP3_P2,STATEV_P2,STATE0_P2,STATE1_P2,&K64[16]);
+		SHA256ROUND_X2(MSGV_P1,MSGTMP1_P1,MSGTMP2_P1,MSGTMP3_P1,MSGTMP0_P1,STATEV_P1,STATE0_P1,STATE1_P1,MSGV_P2,MSGTMP1_P2,MSGTMP2_P2,MSGTMP3_P2,MSGTMP0_P2,STATEV_P2,STATE0_P2,STATE1_P2,&K64[20]);
+		SHA256ROUND_X2(MSGV_P1,MSGTMP2_P1,MSGTMP3_P1,MSGTMP0_P1,MSGTMP1_P1,STATEV_P1,STATE0_P1,STATE1_P1,MSGV_P2,MSGTMP2_P2,MSGTMP3_P2,MSGTMP0_P2,MSGTMP1_P2,STATEV_P2,STATE0_P2,STATE1_P2,&K64[24]);
+		SHA256ROUND_X2(MSGV_P1,MSGTMP3_P1,MSGTMP0_P1,MSGTMP1_P1,MSGTMP2_P1,STATEV_P1,STATE0_P1,STATE1_P1,MSGV_P2,MSGTMP3_P2,MSGTMP0_P2,MSGTMP1_P2,MSGTMP2_P2,STATEV_P2,STATE0_P2,STATE1_P2,&K64[28]);
+
+		// rounds 32-35, 36-39, 40-43, 44-47
+		SHA256ROUND_X2(MSGV_P1,MSGTMP0_P1,MSGTMP1_P1,MSGTMP2_P1,MSGTMP3_P1,STATEV_P1,STATE0_P1,STATE1_P1,MSGV_P2,MSGTMP0_P2,MSGTMP1_P2,MSGTMP2_P2,MSGTMP3_P2,STATEV_P2,STATE0_P2,STATE1_P2,&K64[32]);
+		SHA256ROUND_X2(MSGV_P1,MSGTMP1_P1,MSGTMP2_P1,MSGTMP3_P1,MSGTMP0_P1,STATEV_P1,STATE0_P1,STATE1_P1,MSGV_P2,MSGTMP1_P2,MSGTMP2_P2,MSGTMP3_P2,MSGTMP0_P2,STATEV_P2,STATE0_P2,STATE1_P2,&K64[36]);
+		SHA256ROUND_X2(MSGV_P1,MSGTMP2_P1,MSGTMP3_P1,MSGTMP0_P1,MSGTMP1_P1,STATEV_P1,STATE0_P1,STATE1_P1,MSGV_P2,MSGTMP2_P2,MSGTMP3_P2,MSGTMP0_P2,MSGTMP1_P2,STATEV_P2,STATE0_P2,STATE1_P2,&K64[40]);
+		SHA256ROUND_X2(MSGV_P1,MSGTMP3_P1,MSGTMP0_P1,MSGTMP1_P1,MSGTMP2_P1,STATEV_P1,STATE0_P1,STATE1_P1,MSGV_P2,MSGTMP3_P2,MSGTMP0_P2,MSGTMP1_P2,MSGTMP2_P2,STATEV_P2,STATE0_P2,STATE1_P2,&K64[44]);
+
+		// rounds 48-51
+		MSGV_P1 = vaddq_u32(MSGTMP0_P1,vld1q_u32(&K64[48]));
+		MSGV_P2 = vaddq_u32(MSGTMP0_P2,vld1q_u32(&K64[48]));
+		STATEV_P1 = STATE0_P1;
+		STATEV_P2 = STATE0_P2;
+		STATE0_P1 = vsha256hq_u32(STATE0_P1,STATE1_P1,MSGV_P1);
+		STATE0_P2 = vsha256hq_u32(STATE0_P2,STATE1_P2,MSGV_P2);
+		STATE1_P1 = vsha256h2q_u32(STATE1_P1,STATEV_P1,MSGV_P1);
+		STATE1_P2 = vsha256h2q_u32(STATE1_P2,STATEV_P2,MSGV_P2);
+		MSGTMP3_P1 = vsha256su1q_u32(MSGTMP3_P1,MSGTMP1_P1,MSGTMP2_P1);
+		MSGTMP3_P2 = vsha256su1q_u32(MSGTMP3_P2,MSGTMP1_P2,MSGTMP2_P2);
+
+		// rounds 52-55
+		MSGV_P1 = vaddq_u32(MSGTMP1_P1,vld1q_u32(&K64[52]));
+		MSGV_P2 = vaddq_u32(MSGTMP1_P2,vld1q_u32(&K64[52]));
+		STATEV_P1 = STATE0_P1;
+		STATEV_P2 = STATE0_P2;
+		STATE0_P1 = vsha256hq_u32(STATE0_P1,STATE1_P1,MSGV_P1);
+		STATE0_P2 = vsha256hq_u32(STATE0_P2,STATE1_P2,MSGV_P2);
+		STATE1_P1 = vsha256h2q_u32(STATE1_P1,STATEV_P1,MSGV_P1);
+		STATE1_P2 = vsha256h2q_u32(STATE1_P2,STATEV_P2,MSGV_P2);
+
+		// rounds 56-59
+		MSGV_P1 = vaddq_u32(MSGTMP2_P1,vld1q_u32(&K64[56]));
+		MSGV_P2 = vaddq_u32(MSGTMP2_P2,vld1q_u32(&K64[56]));
+		STATEV_P1 = STATE0_P1;
+		STATEV_P2 = STATE0_P2;
+		STATE0_P1 = vsha256hq_u32(STATE0_P1,STATE1_P1,MSGV_P1);
+		STATE0_P2 = vsha256hq_u32(STATE0_P2,STATE1_P2,MSGV_P2);
+		STATE1_P1 = vsha256h2q_u32(STATE1_P1,STATEV_P1,MSGV_P1);
+		STATE1_P2 = vsha256h2q_u32(STATE1_P2,STATEV_P2,MSGV_P2);
+
+		// rounds 60-63
+		MSGV_P1 = vaddq_u32(MSGTMP3_P1,vld1q_u32(&K64[60]));
+		MSGV_P2 = vaddq_u32(MSGTMP3_P2,vld1q_u32(&K64[60]));
+		STATEV_P1 = STATE0_P1;
+		STATEV_P2 = STATE0_P2;
+		STATE0_P1 = vsha256hq_u32(STATE0_P1,STATE1_P1,MSGV_P1);
+		STATE0_P2 = vsha256hq_u32(STATE0_P2,STATE1_P2,MSGV_P2);
+		STATE1_P1 = vsha256h2q_u32(STATE1_P1,STATEV_P1,MSGV_P1);
+		STATE1_P2 = vsha256h2q_u32(STATE1_P2,STATEV_P2,MSGV_P2);
+
+		// add to state
+		HASH0_SAVE_P1 = vaddq_u32(STATE0_P1,ABCD_INIT);
+		HASH0_SAVE_P2 = vaddq_u32(STATE0_P2,ABCD_INIT);
+		HASH1_SAVE_P1 = vaddq_u32(STATE1_P1,EFGH_INIT);
+		HASH1_SAVE_P2 = vaddq_u32(STATE1_P2,EFGH_INIT);
+	}
+
+	// shuffle/return hash
+	HASH0_SAVE_P1 = vreinterpretq_u32_u8(vrev32q_u8(vreinterpretq_u8_u32(HASH0_SAVE_P1)));
+	HASH1_SAVE_P1 = vreinterpretq_u32_u8(vrev32q_u8(vreinterpretq_u8_u32(HASH1_SAVE_P1)));
+	HASH0_SAVE_P2 = vreinterpretq_u32_u8(vrev32q_u8(vreinterpretq_u8_u32(HASH0_SAVE_P2)));
+	HASH1_SAVE_P2 = vreinterpretq_u32_u8(vrev32q_u8(vreinterpretq_u8_u32(HASH1_SAVE_P2)));
+	vst1q_u32((uint32_t*)(&hash[0]),HASH0_SAVE_P1);
+	vst1q_u32((uint32_t*)(&hash[16]),HASH1_SAVE_P1);
+	vst1q_u32((uint32_t*)(&hash[32]),HASH0_SAVE_P2);
+	vst1q_u32((uint32_t*)(&hash[48]),HASH1_SAVE_P2);
+}
+
+#else // __aarch64__
+
+void recursive_sha256_arm(uint8_t* hash, const uint64_t num_iters) {
+	throw std::logic_error("recursive_sha256_arm() not available");
+}
+
+void recursive_sha256_arm_x2(uint8_t* hash, const uint64_t num_iters) {
+	throw std::logic_error("recursive_sha256_arm_x2() not available");
+}
+
+#endif // __aarch64__
+

--- a/src/sha256_avx2.cpp
+++ b/src/sha256_avx2.cpp
@@ -7,6 +7,7 @@
 
 #include <sha256_avx2.h>
 #include <sha256_ni.h>
+#include <sha256_arm.h>
 #include <mmx/hash_t.hpp>
 
 #include <cstring>


### PR DESCRIPTION
PR for use of **accelerated CPU SHA256 instructions** on **ARM** platforms.

**Goal:** Make CPU SHA256 on ARM performant/efficient.
**Goal:** Implement side-by-side, similar to x64 SHA Extensions (SHA-NI).

Instructions/API:
> ARM have optional [ARM Cryptography Extensions](https://developer.arm.com/documentation/100801/0401/Functional-description/About-the-Cryptographic-Extension?lang=en), with [SHA256 accelerators](https://developer.arm.com/architectures/instruction-sets/intrinsics/#q=sha256):\
`sha256hq, sha256h2q, sha256su0q, sha256su1q`\
Like x64 have [Intel SHA Extensions (SHA-NI)](https://www.intel.com/content/www/us/en/developer/articles/technical/intel-sha-extensions.html):\
`sha256msg1, sha256msg2, sha256rnds2`

Logic:
- Side-by-side current x64 SHA-NI implementation
- Not back-hook into SHA-NI, looked messy
- Side-by-side looked better for any future refactor
- 3x new hash functions, 1x detect (mirrors SHA-NI):
  - `sha256_arm()`
  - `recursive_sha256_arm()`
  - `recursive_sha256_arm_x2()`
  - `sha256_arm_available()`
- Make/#ifdef check of `aarch64`
- Realtime check if ARM Crypto Extensions

Comment:
- If other structure/syntax preferred, just say so. Will rework.

_**DISCLAIMER** (end-users): **Do NOT buy/use Pi5 for MMX node**. Used for prototyping/testing ARM SHA256. Works, got 2x block wins. But Pi5 performance will NOT be viable in future (current TimeLord was 'only' 33 MH/s)._

Testing:
- Unit: Raspberry Pi5 / ARM Cortex-A76 (4x core, 2.4GHz)
- Internal/custom unit testing of the 3x hash functions
- Performance (from: [link1](https://github.com/voidxno/fast-recursive-sha256/blob/main/pipeline_mt/BENCHMARK.md), [link2](https://github.com/voidxno/fast-recursive-sha256/blob/main/pipeline_mt/RESULTS.md)):
```
                   | Rec (_x1)  | Rec (_x2)  | Uplift
-------------------+------------+------------+--------
P-core,    6.0 GHz | 42.42 MH/s | 57.19 MH/s |  +34.8% (Intel 13th-gen)
E-core,    4.3 GHz | 42.02 MH/s | 78.40 MH/s |  +86.5% (Intel 13th-gen)
Zen4-core, 5.1 GHz | 38.36 MH/s | 72.83 MH/s |  +89.8% (AMD 7040-series)
A76-core,  2.4 GHz | 18.41 MH/s | 36.89 MH/s | +100.3% (ARM Cortex-A76, Pi5)
```

Testing (live mmx-node, w/arm_sha256 branch, 33 MH/s network speed):
- Compiled with Linux/gcc12 and Win/VC++ (GitHub actions)
- Pi5 / Linux (TimeLord): ~6.5sec VDF verify, ~15.8 MH/s TL (2x streams)
- Pi5 / Linux (Farming): ~5.0sec VDF verify, won 2x blocks (48h), w/10TB
- Tests of Linux/Win x64 (to be safe):
  - Intel 8700K / Win: Ok (own farm, won blocks)
  - AMD 7840U / Linux & Win: Ok (as TimeLord too)
  - Intel 13900KS / Linux: Ok (TimeLord)

Notes:
- Limited the make/#ifdef checks to only `aarch64`. Could be issues, .h files and so on, if compiled on Apple Silicon (M1/M2). Only have access to Pi5 for ARM. Not sure about Microsoft ARM, or other possible ARM platforms. Tried to keep it simple.
- Kept compile switches to `-march=armv8-a+crypto`. Limits instructions used by compiler to generic ARMv8-A (Neon/SIMD) and Crypto (Extensions). Aiming for high ARM compatibility, together with realtime check for Crypto (Extensions). I.e., only execute Crypto instructions if detected.
- ARM little/big-endian. Don't have practical experience, but do not think it is a problem. ARM SHA256 code samples I looked at, all seemed to use/structure SHA256's 32bit-words identical.