### PR TITLE
add docker support for intel gpus

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -27,12 +27,19 @@ jobs:
           - final-build-stage: 'base'
             latest-tag-behaviour: auto
             version-suffix: ''
+            suffix-onlatest: false
           - final-build-stage: amd
-            latest-tag-behaviour: false
+            latest-tag-behaviour: auto
             version-suffix: '-amd'
+            suffix-onlatest: true
           - final-build-stage: nvidia
-            latest-tag-behaviour: false
+            latest-tag-behaviour: auto
             version-suffix: '-nvidia'
+            suffix-onlatest: true
+          - final-build-stage: intel
+            latest-tag-behaviour: auto
+            version-suffix: '-intel'
+            suffix-onlatest: true
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -46,7 +53,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           flavor: |
             latest=${{ matrix.latest-tag-behaviour }}
-            suffix=${{ matrix.version-suffix }}
+            suffix=${{ matrix.version-suffix }},onlatest=${{ matrix.suffix-onlatest }}
           tags: |
             type=edge
             type=semver,pattern={{version}}

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get -y upgrade \
 		&& apt-get install -y \
 			apt-utils \
+			curl \
 			libminiupnpc17 \
 			libjemalloc2 \
 			zlib1g \

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update && apt-get -y upgrade \
 			ocl-icd-opencl-dev \
 			ccache \
 			&& rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 COPY . .
 RUN git submodule update --init --recursive
@@ -31,9 +32,9 @@ RUN apt-get update && apt-get -y upgrade \
 			libzstd1 \
 			libgomp1 \
 			ocl-icd-libopencl1 \
-			curl \
-			clinfo \
+			tzdata \
 			&& rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 COPY --from=builder /app/build/dist ./
 COPY ["docker-entrypoint.sh", "./"]
@@ -42,7 +43,7 @@ ENV MMX_HOME="/data/"
 VOLUME /data
 
 # node p2p port
-EXPOSE 12341/tcp
+EXPOSE 12342/tcp
 # http api port
 EXPOSE 11380/tcp
 
@@ -67,3 +68,7 @@ RUN mkdir -p /etc/OpenCL/vendors \
     && echo "libnvidia-opencl.so.1" > /etc/OpenCL/vendors/nvidia.icd
 ENV NVIDIA_VISIBLE_DEVICES all
 ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
+
+FROM base AS intel
+RUN apt-get update && apt-get install --no-install-recommends -y intel-opencl-icd \
+	&& rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
this pr brings support for building docker images with intel gpu support. some other minor changes include updated port for testnet 12, removed a couple unused packages, added tzdata for setting proper system time, and additional tags for latest gpu images.

NOTE: the wiki will require some updates to include info and examples for using the intel image. not sure how to contribute there