### PR TITLE
Improvement of OpenCL device discovery and selection

### DIFF
--- a/src/Node.cpp
+++ b/src/Node.cpp
@@ -53,7 +53,7 @@ void Node::main()
 
 		const auto platforms = automy::basic_opencl::get_platforms();
 
-		struct device_t { // NOTE: Element for each OpenCL device found
+		struct device_t {
 			int index = 0;
 			std::string name;
 			std::string platform;
@@ -61,9 +61,9 @@ void Node::main()
 			cl_platform_id platform_id;
 		};
 		std::vector<device_t> list;
-		int listsel = -1; // NOTE: Selection index for GPU entry in list, if found (-1/None if not)
+		int listsel = -1;
 
-		for(const auto idp : platforms) { // NOTE: Find all OpenCL devices, insert in list
+		for(const auto idp : platforms) {
 			const auto devices = automy::basic_opencl::get_devices(idp, CL_DEVICE_TYPE_GPU);
 			const auto platform = automy::basic_opencl::get_platform_name(idp);
 			for(const auto idd : devices) {
@@ -85,21 +85,21 @@ void Node::main()
 		}
 		vnx::write_config("Node.opencl_device_list", device_list);
 
-		if(opencl_device >= 0) { // NOTE: If configured to use OpenCL devices (not -1/None)
-			if(list.size()) { // NOTE: Only if OpenCL devices was found
-				if(!opencl_device_name.empty()) { // NOTE: New config method (not legacy), relative index
+		if(opencl_device >= 0) {
+			if(list.size()) {
+				if(!opencl_device_name.empty()) {
 					for(size_t i = 0; i < list.size() && listsel < 0; ++i) {
 						if(opencl_device_name == list[i].name && opencl_device == list[i].index) {
 							listsel = i;
 						}
 					}
 				}
-				else { // NOTE: No device_name, hybrid behaviour (new/legacy configs), still opencl_device >= 0
-					if(platform_name.empty()) { // NOTE: Set empty platform_name to first platform, it exists (temporary, not config file)
+				else {
+					if(platform_name.empty()) {
 						platform_name = list[0].platform;
 					}
 					int devidx = -1;
-					for(size_t i = 0; i < list.size() && listsel < 0; ++i) { // NOTE: Search devices on 1x named platform, see if opencl_device index exists
+					for(size_t i = 0; i < list.size() && listsel < 0; ++i) {
 						if(platform_name == list[i].platform) {
 							devidx++;
 						}
@@ -108,7 +108,7 @@ void Node::main()
 						}
 					}
 				}
-				if(listsel >= 0) { // NOTE: Found OpenCL device in list to use
+				if(listsel >= 0) {
 					const auto& device = list[listsel];
 					opencl_context = automy::basic_opencl::create_context(device.platform_id, {device.device_id});
 
@@ -118,19 +118,19 @@ void Node::main()
 					}
 					log(INFO) << "Using OpenCL GPU device '" << device.name << "' [" << device.index << "] (" << device.platform << ")";
 				}
-				else { // NOTE: No OpenCL in list found, fail/fallback to -1/None
+				else {
 					log(WARN) << "No such OpenCL GPU device '" << opencl_device_name << "' [" << opencl_device << "]";
 				}
 			}
-			else { // NOTE: No OpenCL devices found, default to -1/None
+			else {
 				log(INFO) << "No OpenCL devices found";
 			}
 		}
-		else { // NOTE: Config is -1/None
+		else {
 			log(INFO) << "No OpenCL device used (disabled)";
 		}
 
-		vnx::write_config("Node.opencl_device_select", listsel); // NOTE: Communicate 'OpenCL Device' selection WebGUI, temporary config (RAM only)
+		vnx::write_config("Node.opencl_device_select", listsel);
 	}
 	catch(const std::exception& ex) {
 		log(WARN) << "Failed to create OpenCL GPU context: " << ex.what();

--- a/src/WebAPI.cpp
+++ b/src/WebAPI.cpp
@@ -1144,7 +1144,7 @@ void WebAPI::http_request_async(std::shared_ptr<const vnx::addons::HttpRequest> 
 			const auto value = iter_value->second;
 			vnx::set_config(key, value);
 
-			const bool tmp_only = args["tmp_only"]; // NOTE: Optional boolean option to write or not to config file (.json), default 'false'
+			const bool tmp_only = args["tmp_only"];
 			if(!tmp_only) {
 				std::string file;
 				vnx::optional<std::string> field;

--- a/src/WebAPI.cpp
+++ b/src/WebAPI.cpp
@@ -1138,14 +1138,13 @@ void WebAPI::http_request_async(std::shared_ptr<const vnx::addons::HttpRequest> 
 		std::lock_guard lock(g_config_mutex);
 		const auto iter_key = args.field.find("key");
 		const auto iter_value = args.field.find("value");
-		const auto iter_tmp_only = args.field.find("tmp_only"); // NOTE: Optional boolean option to write or not to config file (.json), default 'false'
 		if(iter_key != args.field.end() && iter_value != args.field.end())
 		{
 			const auto key = iter_key->second.to_string_value();
 			const auto value = iter_value->second;
 			vnx::set_config(key, value);
 
-			const bool tmp_only = iter_tmp_only != args.field.end() ? (iter_tmp_only->second.is_bool() ? iter_tmp_only->second : false) : false;
+			const bool tmp_only = args["tmp_only"]; // NOTE: Optional boolean option to write or not to config file (.json), default 'false'
 			if(!tmp_only) {
 				std::string file;
 				vnx::optional<std::string> field;

--- a/src/WebAPI.cpp
+++ b/src/WebAPI.cpp
@@ -1138,15 +1138,15 @@ void WebAPI::http_request_async(std::shared_ptr<const vnx::addons::HttpRequest> 
 		std::lock_guard lock(g_config_mutex);
 		const auto iter_key = args.field.find("key");
 		const auto iter_value = args.field.find("value");
-		const auto iter_file = args.field.find("file"); // NOTE: Boolean option to write or not to config file (.json)
-		if(iter_key != args.field.end() && iter_value != args.field.end() && iter_file != args.field.end())
+		const auto iter_tmp_only = args.field.find("tmp_only"); // NOTE: Optional boolean option to write or not to config file (.json), default 'false'
+		if(iter_key != args.field.end() && iter_value != args.field.end())
 		{
 			const auto key = iter_key->second.to_string_value();
 			const auto value = iter_value->second;
 			vnx::set_config(key, value);
 
-			const auto file = iter_file->second.is_bool() ? iter_file->second : true;
-			if(file) {
+			const bool tmp_only = iter_tmp_only != args.field.end() ? (iter_tmp_only->second.is_bool() ? iter_tmp_only->second : false) : false;
+			if(!tmp_only) {
 				std::string file;
 				vnx::optional<std::string> field;
 				{
@@ -1172,7 +1172,7 @@ void WebAPI::http_request_async(std::shared_ptr<const vnx::addons::HttpRequest> 
 			}
 			respond_status(request_id, 200);
 		} else {
-			respond_status(request_id, 400, "POST config/set {key,value,file}");
+			respond_status(request_id, 400, "POST config/set {key, value, [tmp_only]}");
 		}
 	}
 	else if(sub_path == "/exit" || sub_path == "/node/exit") {

--- a/www/explorer/public/locales/en.js
+++ b/www/explorer/public/locales/en.js
@@ -291,6 +291,8 @@ const enLocale = {
         "enable_timelord_reward": "Enable TimeLord Rewards (requires one more CPU core)",
         "verify_timelord_reward": "Verify TimeLord Rewards (disable to speed up VDF verify)",
         "open_port": "Open network port to allow incoming connections (UPnP)",
+
+        "reward": "Reward",
         "farmer_reward_address": "Farmer Reward Address",
         "timeLord_reward_address": "TimeLord Reward Address",
         "restart_needed": "(restart needed to apply)",

--- a/www/web-gui/public/locales/en.js
+++ b/www/web-gui/public/locales/en.js
@@ -291,6 +291,8 @@ const enLocale = {
         "enable_timelord_reward": "Enable TimeLord Rewards (requires one more CPU core)",
         "verify_timelord_reward": "Verify TimeLord Rewards (disable to speed up VDF verify)",
         "open_port": "Open network port to allow incoming connections (UPnP)",
+
+        "reward": "Reward",
         "farmer_reward_address": "Farmer Reward Address",
         "timeLord_reward_address": "TimeLord Reward Address",
         "restart_needed": "(restart needed to apply)",

--- a/www/web-gui/public/settings.js
+++ b/www/web-gui/public/settings.js
@@ -35,10 +35,9 @@ Vue.component('node-settings', {
 					{
 						let list = data["Node.opencl_device_list"]; // NOTE: List of devices from Node.cpp (pair with name and relative index)
 						if(list) {
-							let i = 0;
-							for(const device of list) {
+							for(const [i, device] of list.entries()) {
 								this.opencl_device_list_relidx.push({name: device[0], index: device[1]});
-								this.opencl_device_list.push({name: device[0], value: i++});
+								this.opencl_device_list.push({name: device[0], value: i});
 							}
 						}
 					}

--- a/www/web-gui/public/settings.js
+++ b/www/web-gui/public/settings.js
@@ -7,7 +7,7 @@ Vue.component('node-settings', {
 			loading: true,
 			timelord: null,
 			open_port: null,
-			opencl_device_list_relidx: null, // NOTE: List of OpenCL devices from Node.cpp (pair with name and relative index)
+			opencl_device_list_relidx: null,
 			opencl_device: null,
 			opencl_device_list: null,
 			farmer_reward_addr: "null",
@@ -29,11 +29,11 @@ Vue.component('node-settings', {
 					this.loading = false;
 					this.timelord = data.timelord ? true : false;
 					this.open_port = data["Router.open_port"] ? true : false;
-					this.opencl_device = data["Node.opencl_device_select"] ?? -1; // NOTE: Current List selection (not relative, value index in WebGUI list), from temporary config (RAM only) value, not value written to config .json (to support refresh of WebGUI browser)
+					this.opencl_device = data["Node.opencl_device_select"] ?? -1;
 					this.opencl_device_list_relidx = [];
-					this.opencl_device_list = [{name: "None", value: -1}]; // NOTE: WebGUI list of OpenCL devices, with added -1/None
+					this.opencl_device_list = [{name: "None", value: -1}];
 					{
-						let list = data["Node.opencl_device_list"]; // NOTE: List of devices from Node.cpp (pair with name and relative index)
+						let list = data["Node.opencl_device_list"];
 						if(list) {
 							for(const [i, device] of list.entries()) {
 								this.opencl_device_list_relidx.push({name: device[0], index: device[1]});
@@ -49,7 +49,7 @@ Vue.component('node-settings', {
 					this.plot_dirs = data["Harvester.plot_dirs"];
 				});
 		},
-		set_config(key, value, restart, tmp_only = false) { // NOTE: Added optional boolean option to write or not to config file (.json), default 'false'
+		set_config(key, value, restart, tmp_only = false) {
 			var req = {};
 			req.key = key;
 			req.value = value;
@@ -146,10 +146,10 @@ Vue.component('node-settings', {
 		},
 		opencl_device(value, prev) {
 			if(prev != null) {
-				this.set_config("Node.opencl_device_select", value, true, true); // NOTE: Temporary current device selection WebGUI (no config file write), survive browser reload
-				this.set_config("opencl.platform", null, true); // NOTE: Config change made, force any existing platform name config to ""
-				this.set_config("Node.opencl_device", (value >= 0) ? this.opencl_device_list_relidx[value].index : -1, true); // NOTE: Write real relative index config value to .json file, for device, or -1/None
-				this.set_config("Node.opencl_device_name", (value >= 0) ? this.opencl_device_list_relidx[value].name : null, true); // NOTE: Device name last, visually shown 'restart needed to apply' (WebGUI), usually (threading)
+				this.set_config("Node.opencl_device_select", value, true, true);
+				this.set_config("opencl.platform", null, true);
+				this.set_config("Node.opencl_device", (value >= 0) ? this.opencl_device_list_relidx[value].index : -1, true);
+				this.set_config("Node.opencl_device_name", (value >= 0) ? this.opencl_device_list_relidx[value].name : null, true);
 			}
 		},
 		farmer_reward_addr(value, prev) {
@@ -256,12 +256,8 @@ Vue.component('node-settings', {
 				</v-card-text>
 			</v-card>
 
-			<!-- -------------------------------------------------------------------------------------------------- -->
-			<!-- NOTE: Suggestion to create a separate split/card/header for reward addresses (they are important)  -->
-			<!-- TODO: If going to stay, rework 'Reward' text to label text from settings                           -->
-			<!-- -------------------------------------------------------------------------------------------------- -->
 			<v-card class="my-2">
-				<v-card-title>{{ "Reward" }}</v-card-title>
+				<v-card-title>{{ $t('node_settings.reward') }}</v-card-title>
 				<v-card-text>
 					<v-text-field
 						:label="$t('node_settings.farmer_reward_address')"

--- a/www/web-gui/public/settings.js
+++ b/www/web-gui/public/settings.js
@@ -50,15 +50,15 @@ Vue.component('node-settings', {
 					this.plot_dirs = data["Harvester.plot_dirs"];
 				});
 		},
-		set_config(key, value, restart, tmp_only) { // NOTE: Added optional boolean option to write or not to config file (.json), default 'false'
+		set_config(key, value, restart, tmp_only = false) { // NOTE: Added optional boolean option to write or not to config file (.json), default 'false'
 			var req = {};
 			req.key = key;
 			req.value = value;
-			req.tmp_only = tmp_only ?? false;
+			req.tmp_only = tmp_only;
 			fetch('/wapi/config/set', {body: JSON.stringify(req), method: "post"})
 				.then(response => {
 					if(response.ok) {
-						this.result = {key: req.key, value: req.value, restart, tmp_only: req.tmp_only};
+						this.result = {key: req.key, value: req.value, restart};
 					} else {
 						response.text().then(data => {
 							this.error = data;
@@ -149,8 +149,8 @@ Vue.component('node-settings', {
 			if(prev != null) {
 				this.set_config("Node.opencl_device_select", value, true, true); // NOTE: Temporary current device selection WebGUI (no config file write), survive browser reload
 				this.set_config("opencl.platform", null, true); // NOTE: Config change made, force any existing platform name config to ""
-				this.set_config("Node.opencl_device", (value >= 0) ? this.opencl_device_list_relidx[value]["index"] : -1, true); // NOTE: Write real relative index config value to .json file, for device, or -1/None
-				this.set_config("Node.opencl_device_name", (value >= 0) ? this.opencl_device_list_relidx[value]["name"] : null, true); // NOTE: Device name last, visually shown 'restart needed to apply' (WebGUI), usually (threading)
+				this.set_config("Node.opencl_device", (value >= 0) ? this.opencl_device_list_relidx[value].index : -1, true); // NOTE: Write real relative index config value to .json file, for device, or -1/None
+				this.set_config("Node.opencl_device_name", (value >= 0) ? this.opencl_device_list_relidx[value].name : null, true); // NOTE: Device name last, visually shown 'restart needed to apply' (WebGUI), usually (threading)
 			}
 		},
 		farmer_reward_addr(value, prev) {

--- a/www/web-gui/public/settings.js
+++ b/www/web-gui/public/settings.js
@@ -29,7 +29,7 @@ Vue.component('node-settings', {
 					this.loading = false;
 					this.timelord = data.timelord ? true : false;
 					this.open_port = data["Router.open_port"] ? true : false;
-					this.opencl_device = data["Node.opencl_device_select"] != null ? data["Node.opencl_device_select"] : -1; // NOTE: Current List selection (not relative, value index in WebGUI list), from temporary config (RAM only) value, not value written to config .json (to support refresh of WebGUI browser)
+					this.opencl_device = data["Node.opencl_device_select"] ?? -1; // NOTE: Current List selection (not relative, value index in WebGUI list), from temporary config (RAM only) value, not value written to config .json (to support refresh of WebGUI browser)
 					this.opencl_device_list_relidx = [];
 					this.opencl_device_list = [{name: "None", value: -1}]; // NOTE: WebGUI list of OpenCL devices, with added -1/None
 					{
@@ -50,15 +50,15 @@ Vue.component('node-settings', {
 					this.plot_dirs = data["Harvester.plot_dirs"];
 				});
 		},
-		set_config(key, value, file, restart) { // NOTE: Added boolean option to write or not to config file (.json)
+		set_config(key, value, restart, tmp_only) { // NOTE: Added optional boolean option to write or not to config file (.json), default 'false'
 			var req = {};
 			req.key = key;
 			req.value = value;
-			req.file = file;
+			req.tmp_only = tmp_only ?? false;
 			fetch('/wapi/config/set', {body: JSON.stringify(req), method: "post"})
 				.then(response => {
 					if(response.ok) {
-						this.result = {key: req.key, value: req.value, file: req.file, restart};
+						this.result = {key: req.key, value: req.value, restart, tmp_only: req.tmp_only};
 					} else {
 						response.text().then(data => {
 							this.error = data;
@@ -137,55 +137,55 @@ Vue.component('node-settings', {
 	watch: {
 		timelord(value, prev) {
 			if(prev != null) {
-				this.set_config("timelord", value, true, true);
+				this.set_config("timelord", value, true);
 			}
 		},
 		open_port(value, prev) {
 			if(prev != null) {
-				this.set_config("Router.open_port", value, true, true);
+				this.set_config("Router.open_port", value, true);
 			}
 		},
 		opencl_device(value, prev) {
 			if(prev != null) {
-				this.set_config("Node.opencl_device_select", value, false, true); // NOTE: Temporary current device selection WebGUI (no config file write), survive browser reload
-				this.set_config("opencl.platform", null, true, true); // NOTE: Config change made, force any existing platform name config to ""
-				this.set_config("Node.opencl_device", (value >= 0) ? this.opencl_device_list_relidx[value]["index"] : -1, true, true); // NOTE: Write real relative index config value to .json file, for device, or -1/None
-				this.set_config("Node.opencl_device_name", (value >= 0) ? this.opencl_device_list_relidx[value]["name"] : null, true, true); // NOTE: Device name last, visually shown 'restart needed to apply' (WebGUI), usually (threading)
+				this.set_config("Node.opencl_device_select", value, true, true); // NOTE: Temporary current device selection WebGUI (no config file write), survive browser reload
+				this.set_config("opencl.platform", null, true); // NOTE: Config change made, force any existing platform name config to ""
+				this.set_config("Node.opencl_device", (value >= 0) ? this.opencl_device_list_relidx[value]["index"] : -1, true); // NOTE: Write real relative index config value to .json file, for device, or -1/None
+				this.set_config("Node.opencl_device_name", (value >= 0) ? this.opencl_device_list_relidx[value]["name"] : null, true); // NOTE: Device name last, visually shown 'restart needed to apply' (WebGUI), usually (threading)
 			}
 		},
 		farmer_reward_addr(value, prev) {
 			if(prev != "null") {
-				this.set_config("Farmer.reward_addr", value.length ? value : null, true, true);
+				this.set_config("Farmer.reward_addr", value.length ? value : null, true);
 			}
 		},
 		timelord_reward_addr(value, prev) {
 			if(prev != "null") {
-				this.set_config("TimeLord.reward_addr", value.length ? value : null, true, true);
+				this.set_config("TimeLord.reward_addr", value.length ? value : null, true);
 			}
 		},
 		enable_timelord_reward(value, prev) {
 			if(prev != null) {
-				this.set_config("TimeLord.enable_reward", value, true, true);
+				this.set_config("TimeLord.enable_reward", value, true);
 			}
 		},
 		verify_timelord_reward(value, prev) {
 			if(prev != null) {
-				this.set_config("Node.verify_vdf_rewards", value, true, true);
+				this.set_config("Node.verify_vdf_rewards", value, true);
 			}
 		},
 		harv_num_threads(value, prev) {
 			if(prev != null) {
-				this.set_config("Harvester.num_threads", value, true, true);
+				this.set_config("Harvester.num_threads", value, true);
 			}
 		},
 		recursive_search(value, prev) {
 			if(prev != null) {
-				this.set_config("Harvester.recursive_search", value ? true : false, true, true);
+				this.set_config("Harvester.recursive_search", value ? true : false, true);
 			}
 		},
 		reload_interval(value, prev) {
 			if(prev != null) {
-				this.set_config("Harvester.reload_interval", value, true, true);
+				this.set_config("Harvester.reload_interval", value, true);
 			}
 		},
 		result(value) {


### PR DESCRIPTION
PR for fix of OpenCL device problems described in **[issue #268](https://github.com/madMAx43v3r/mmx-node/issues/268)**

_NOTE: **Only review/feedback at this stage** (complete try that is working though)_

**Goal:** Solve problem of identical platform, or device names
**Goal:** Legacy/migrate/support existing config value logic
**Goal:** Single WebGUI selection list (all devices, all platforms)
**Goal:** Possible to find/configure OpenCL device without WebGUI
**Goal:** Keep logic simple

Logic (new):
- Enum all OpenCL devices, on all platforms, in a list, log(INFO)
- If `opencl_device` is `-1`, overrides everything, 'None' (CPU)
- If no OpenCL devices, fallback to 'None' (CPU)
- If `opencl_device_name` is defined (new logic)
  - Search list `opencl_device_name` hits, independent of platform, match if counter equals `opencl_device`
  - If not found, log(WARN), fallback to 'None' (CPU)
- If `opencl_device_name` empty (hybrid/old logic)
  - If `platform` (name) empty, define it temporarily to [0] platform
  - Search list for devices with `platform` name, match if counter equals `opencl_device`
  - If not found, log(WARN), fallback to 'None' (CPU)

Comments:
- All comments in code will be removed before any final merge/PR
- Existing .json config never changed, until selection change in WebGUI
- 'First device found' eliminated visually, still works behind the scenes
- log(INFO) of discovered OpenCL devices, makes manual .json config possible

<ins>**Questions**:</ins>
- Anything you observe/want adjusted, valid, just give feedback
- ~~I have a problem with keep-it-simple and `Node.opencl_device_selidx` value (written to .json):~~
  - ~~Want a persistent/temporary value in WebGUI, on browser reload, without permanent .json write~~
  - ~~If not, will have to duplicate 'device selection' logic from Node.cpp into settings.js (don't want to)~~
- Added a new 'Reward' separator split/card/header in WebGUI (just a suggestion)

Log (sample):
```
[Node] INFO: Found OpenCL GPU device 'NVIDIA GeForce RTX 3050' [0] (NVIDIA CUDA)
[Node] INFO: Found OpenCL GPU device 'NVIDIA GeForce GT 1030' [0] (NVIDIA CUDA)
[Node] INFO: Found OpenCL GPU device 'Intel(R) Graphics [0x7d67]' [0] (Intel(R) OpenCL Graphics)
[Node] INFO: Using OpenCL GPU device 'NVIDIA GeForce RTX 3050' [0] (NVIDIA CUDA)
```

WebGUI (sample):
```
OpenCL Device (selection list):
- None
- NVIDIA GeForce RTX 3050
- NVIDIA GeForce GT 1030
- Intel(R) Graphics [0x7d67]
```