### PR TITLE
clarify wallet seed kdf

### DIFF
--- a/include/mmx/ECDSA_Wallet.h
+++ b/include/mmx/ECDSA_Wallet.h
@@ -88,7 +88,7 @@ public:
 		if(addresses.size()) {
 			first_addr = addresses[0];
 		}
-		const auto master = pbkdf2_hmac_sha512(seed_value, passphrase, PBKDF2_ITERS);
+		const auto master = kdf_hmac_sha512(seed_value, passphrase, KDF_ITERS);
 		const auto chain = hmac_sha512_n(master.first, master.second, 11337);
 		const auto account = hmac_sha512_n(chain.first, chain.second, config.index);
 
@@ -559,7 +559,7 @@ public:
 private:
 	void create_farmer_key()
 	{
-		const auto master = pbkdf2_hmac_sha512(seed_value, hash_t("MMX/farmer_keys"), PBKDF2_ITERS);
+		const auto master = kdf_hmac_sha512(seed_value, hash_t("MMX/farmer_keys"), KDF_ITERS);
 		const auto tmp = hmac_sha512_n(master.first, master.second, 0);
 		farmer_key.first = skey_t(tmp.first);
 		farmer_key.second = pubkey_t(skey_t(tmp.first));
@@ -575,7 +575,7 @@ private:
 
 	const std::shared_ptr<const ChainParams> params;
 
-	static constexpr size_t PBKDF2_ITERS = 4096;
+	static constexpr size_t KDF_ITERS = 4096;
 
 };
 

--- a/include/mmx/hmac_sha512.hpp
+++ b/include/mmx/hmac_sha512.hpp
@@ -48,8 +48,9 @@ inline std::pair<hash_t, hash_t> hmac_sha512_n(const hash_t& seed, const hash_t&
 	return out;
 }
 
-inline std::pair<hash_t, hash_t> pbkdf2_hmac_sha512(const hash_t& seed, const hash_t& key, const uint32_t num_iters)
+inline std::pair<hash_t, hash_t> kdf_hmac_sha512(const hash_t& seed, const hash_t& key, const uint32_t num_iters)
 {
+	// This is NOT standard PBKDF2, but a simplified adaptation.
 	uint8_t tmp[64] = {};
 
 	HMAC_SHA512 func(key.data(), key.size());


### PR DESCRIPTION
rename from `pbkdf2_` to `kdf_` to put future readers on the right track