### PR TITLE
Add environment variables to docker for remote services

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,6 +1,27 @@
 #!/bin/bash
-set -em
 
-source ./activate.sh
+config_path="${MMX_HOME}config/local/"
 
-"$@"
+if [ -d "$config_path" ]; then
+
+	if [[ "${MMX_ALLOW_REMOTE}" == "true" ]]; then
+	  echo true > "${config_path}allow_remote" && echo "*** Remote Access Enabled ***"
+	elif [[ "${MMX_ALLOW_REMOTE}" == "false" ]]; then
+	  echo false > "${config_path}allow_remote" && echo "*** Remote Access Disabled ***"
+	fi
+
+	if [[ "${MMX_HARVESTER_ENABLED}" == "true" ]]; then
+	  echo true > "${config_path}harvester" && echo "*** Harvester Enabled ***"
+	elif [[ "${MMX_HARVESTER_ENABLED}" == "false" ]]; then
+	  echo false > "${config_path}harvester" && echo "*** Harvester Disabled ***"
+	fi
+
+	if [[ "${MMX_FARMER_ENABLED}" == "true" ]]; then
+	  echo true > "${config_path}farmer" && echo "*** Farmer Enabled ***"
+	elif [[ "${MMX_FARMER_ENABLED}" == "false" ]]; then
+	  echo false > "${config_path}farmer" && echo "*** Farmer Disabled ***"
+	fi
+
+fi
+
+exec "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,27 +1,25 @@
 #!/bin/bash
 
+source ./activate.sh
+
 config_path="${MMX_HOME}config/local/"
 
-if [ -d "$config_path" ]; then
+if [[ "${MMX_ALLOW_REMOTE}" == "true" ]]; then
+  echo true > "${config_path}allow_remote" && echo "*** Remote Access Enabled ***"
+elif [[ "${MMX_ALLOW_REMOTE}" == "false" ]]; then
+  echo false > "${config_path}allow_remote" && echo "*** Remote Access Disabled ***"
+fi
 
-	if [[ "${MMX_ALLOW_REMOTE}" == "true" ]]; then
-	  echo true > "${config_path}allow_remote" && echo "*** Remote Access Enabled ***"
-	elif [[ "${MMX_ALLOW_REMOTE}" == "false" ]]; then
-	  echo false > "${config_path}allow_remote" && echo "*** Remote Access Disabled ***"
-	fi
+if [[ "${MMX_HARVESTER_ENABLED}" == "true" ]]; then
+  echo true > "${config_path}harvester" && echo "*** Harvester Enabled ***"
+elif [[ "${MMX_HARVESTER_ENABLED}" == "false" ]]; then
+  echo false > "${config_path}harvester" && echo "*** Harvester Disabled ***"
+fi
 
-	if [[ "${MMX_HARVESTER_ENABLED}" == "true" ]]; then
-	  echo true > "${config_path}harvester" && echo "*** Harvester Enabled ***"
-	elif [[ "${MMX_HARVESTER_ENABLED}" == "false" ]]; then
-	  echo false > "${config_path}harvester" && echo "*** Harvester Disabled ***"
-	fi
-
-	if [[ "${MMX_FARMER_ENABLED}" == "true" ]]; then
-	  echo true > "${config_path}farmer" && echo "*** Farmer Enabled ***"
-	elif [[ "${MMX_FARMER_ENABLED}" == "false" ]]; then
-	  echo false > "${config_path}farmer" && echo "*** Farmer Disabled ***"
-	fi
-
+if [[ "${MMX_FARMER_ENABLED}" == "true" ]]; then
+  echo true > "${config_path}farmer" && echo "*** Farmer Enabled ***"
+elif [[ "${MMX_FARMER_ENABLED}" == "false" ]]; then
+  echo false > "${config_path}farmer" && echo "*** Farmer Disabled ***"
 fi
 
 exec "$@"

--- a/src/mmx_node.cpp
+++ b/src/mmx_node.cpp
@@ -161,6 +161,7 @@ int main(int argc, char** argv)
 	std::string api_token_header;
 	{
 		vnx::Handle<vnx::addons::HttpServer> module = new vnx::addons::HttpServer("HttpServer");
+		module->default_access = "NETWORK";
 		module->components["/server/"] = "HttpServer";
 		module->components["/wapi/"] = "WebAPI";
 		module->components["/api/node/"] = "Node";


### PR DESCRIPTION
This will allow users to easily set `allow_remote` as well as enable/disable harvesters and farmers at runtime