### PR TITLE
Update docker usage guide

### DIFF
--- a/docs/src/content/docs/guides/docker.md
+++ b/docs/src/content/docs/guides/docker.md
@@ -1,0 +1,128 @@
+---
+title: Docker Usage
+description: Examples for using pre-built docker images
+---
+
+## Node Containers
+
+Docker images are available via `ghcr.io/madmax43v3r/mmx-node` in 2 build flavours:
+- `latest`: Built from the most recent release version
+- `edge`: Built from the most recent commit to the master branch
+
+Additionally, each semver tag produces tagged images using the same three flavours from above: `<major>.<minor>.<patch>`, `<major>.<minor>` and `<major>` each with their respective suffix (eg. `0.9.5-amd`)
+
+Each image provides a volume for `/data` which you can override with your own volume or a mapped path to customize the storage location of the node data.
+
+### CPU only
+
+A `compose.yml` for the cpu only node can look like this:
+```yml
+services:
+  node:
+    image: ghcr.io/madmax43v3r/mmx-node:latest
+    restart: unless-stopped
+    volumes:
+      - /some/path/to/mmx-node:/data
+    ports:
+      - "11337:11337"  # Node p2p port. Forward your router to this port for peers to be able to connect
+      #- "127.0.0.1:11380:11380"  # API port. Uncomment and set host to 0.0.0.0 in config/local/HttpServer.json for webUI/API access
+      #- "11333:11333"  # Harvester port. Uncomment to allow remote harvesters to connect to the farmer
+      #- "11330:11330"  # Farmer port. Uncomment to allow remote farmers to connect to the node
+```
+
+### AMD GPU
+
+For amd gpu support please see the following `compose.yml`:
+```yml
+services:
+  node:
+    image: ghcr.io/madmax43v3r/mmx-node:latest-amd
+    restart: unless-stopped
+    group_add:
+      - video
+      - render
+    devices:
+      - /dev/dri:/dev/dri
+      - /dev/kfd:/dev/kfd
+    volumes:
+      - /some/path/to/mmx-node:/data
+    ports:
+      - "11337:11337"  # Node p2p port. Forward your router to this port for peers to be able to connect
+      #- "127.0.0.1:11380:11380"  # API port. Uncomment and set host to 0.0.0.0 in config/local/HttpServer.json for webUI/API access
+      #- "11333:11333"  # Harvester port. Uncomment to allow remote harvesters to connect to the farmer
+      #- "11330:11330"  # Farmer port. Uncomment to allow remote farmers to connect to the node
+```
+
+### Intel GPU
+
+For intel gpu support please see the following `compose.yml`:
+```yml
+services:
+  node:
+    image: ghcr.io/madmax43v3r/mmx-node:latest-intel
+    restart: unless-stopped
+    group_add:
+      - video
+      - render
+    devices:
+      - /dev/dri/renderD128:/dev/dri/renderD128
+    volumes:
+      - /some/path/to/mmx-node:/data
+    ports:
+      - "11337:11337"  # Node p2p port. Forward your router to this port for peers to be able to connect
+      #- "127.0.0.1:11380:11380"  # API port. Uncomment and set host to 0.0.0.0 in config/local/HttpServer.json for webUI/API access
+      #- "11333:11333"  # Harvester port. Uncomment to allow remote harvesters to connect to the farmer
+      #- "11330:11330"  # Farmer port. Uncomment to allow remote farmers to connect to the node
+```
+
+Note: `- render` in `group_add` might need to be removed, depending on your system.
+
+### NVIDIA GPU
+
+For nvidia gpu support please see the following `compose.yml`:
+```yml
+services:
+  node:
+    image: ghcr.io/madmax43v3r/mmx-node:latest-nvidia
+    restart: unless-stopped
+    runtime: nvidia
+    volumes:
+      - /some/path/to/mmx-node:/data
+    ports:
+      - "11337:11337"  # Node p2p port. Forward your router to this port for peers to be able to connect
+      #- "127.0.0.1:11380:11380"  # API port. Uncomment and set host to 0.0.0.0 in config/local/HttpServer.json for webUI/API access
+      #- "11333:11333"  # Harvester port. Uncomment to allow remote harvesters to connect to the farmer
+      #- "11330:11330"  # Farmer port. Uncomment to allow remote farmers to connect to the node
+```
+Note: for nvidia you also need the `NVIDIA Container Toolkit` installed on the host, for more info please see: https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html
+
+## Remote Services
+
+Running a remote harvester or farmer can be done by overwriting the `CMD` of the Dockerfile, for example like this:
+
+### Remote Harvester
+```yml
+services:
+  harvester:
+    image: ghcr.io/madmax43v3r/mmx-node:latest
+    restart: unless-stopped
+    command: './run_harvester.sh -n <some ip or hostname here>'
+    volumes:
+      - /some/path/to/mmx-node:/data
+      - /some/path/to/disks:/disks
+```
+Note: The harvester must be able to connect to the remote farmer on port 11333. See examples above and below
+
+### Remote Farmer
+```yml
+services:
+  farmer:
+    image: ghcr.io/madmax43v3r/mmx-node:latest
+    restart: unless-stopped
+    command: './run_farmer.sh -n <some ip or hostname here>'
+    volumes:
+      - /some/path/to/mmx-node:/data
+    ports:
+      - "11333:11333"  # Farmer listens on this port for remote harvester connections
+```
+Note: The farmer must be able to connect to the remote node on port 11330. See examples above

--- a/docs/src/content/docs/guides/docker.md
+++ b/docs/src/content/docs/guides/docker.md
@@ -9,7 +9,16 @@ Docker images are available via `ghcr.io/madmax43v3r/mmx-node` in 2 build flavou
 - `latest`: Built from the most recent release version
 - `edge`: Built from the most recent commit to the master branch
 
-Additionally, each semver tag produces tagged images using the same three flavours from above: `<major>.<minor>.<patch>`, `<major>.<minor>` and `<major>` each with their respective suffix (eg. `0.9.5-amd`)
+The following tag suffixes are also available for GPU vendor specific builds:
+ - `-amd`
+ - `-intel`
+ - `-nvidia`
+
+Additionally, each semver tag produces tagged images:
+ - `<major>.<minor>.<patch>`
+ - `<major>.<minor>`
+ - `<major>`
+ - each with their respective suffix (eg. `1.1.9-amd`)
 
 Each image provides a volume for `/data` which you can override with your own volume or a mapped path to customize the storage location of the node data.
 
@@ -25,9 +34,13 @@ services:
       - /some/path/to/mmx-node:/data
     ports:
       - "11337:11337"  # Node p2p port. Forward your router to this port for peers to be able to connect
-      #- "127.0.0.1:11380:11380"  # API port. Uncomment and set host to 0.0.0.0 in config/local/HttpServer.json for webUI/API access
+      - "127.0.0.1:11380:11380"  # API port. Set host to 0.0.0.0 in /data/config/local/HttpServer.json for webUI/API access
       #- "11333:11333"  # Harvester port. Uncomment to allow remote harvesters to connect to the farmer
       #- "11330:11330"  # Farmer port. Uncomment to allow remote farmers to connect to the node
+    environment:
+      MMX_ALLOW_REMOTE: 'false'  # Set to true to allow connections from remote harvesters/farmers
+      MMX_HARVESTER_ENABLED: 'true'  # Set to false to disable local harvester
+      MMX_FARMER_ENABLED: 'true'  # Set to false to disable local farmer
 ```
 
 ### AMD GPU
@@ -38,9 +51,6 @@ services:
   node:
     image: ghcr.io/madmax43v3r/mmx-node:latest-amd
     restart: unless-stopped
-    group_add:
-      - video
-      - render
     devices:
       - /dev/dri:/dev/dri
       - /dev/kfd:/dev/kfd
@@ -48,9 +58,13 @@ services:
       - /some/path/to/mmx-node:/data
     ports:
       - "11337:11337"  # Node p2p port. Forward your router to this port for peers to be able to connect
-      #- "127.0.0.1:11380:11380"  # API port. Uncomment and set host to 0.0.0.0 in config/local/HttpServer.json for webUI/API access
+      - "127.0.0.1:11380:11380"  # API port. Set host to 0.0.0.0 in /data/config/local/HttpServer.json for webUI/API access
       #- "11333:11333"  # Harvester port. Uncomment to allow remote harvesters to connect to the farmer
       #- "11330:11330"  # Farmer port. Uncomment to allow remote farmers to connect to the node
+    environment:
+      MMX_ALLOW_REMOTE: 'false'  # Set to true to allow connections from remote harvesters/farmers
+      MMX_HARVESTER_ENABLED: 'true'  # Set to false to disable local harvester
+      MMX_FARMER_ENABLED: 'true'  # Set to false to disable local farmer
 ```
 
 ### Intel GPU
@@ -61,21 +75,21 @@ services:
   node:
     image: ghcr.io/madmax43v3r/mmx-node:latest-intel
     restart: unless-stopped
-    group_add:
-      - video
-      - render
     devices:
       - /dev/dri/renderD128:/dev/dri/renderD128
     volumes:
       - /some/path/to/mmx-node:/data
     ports:
       - "11337:11337"  # Node p2p port. Forward your router to this port for peers to be able to connect
-      #- "127.0.0.1:11380:11380"  # API port. Uncomment and set host to 0.0.0.0 in config/local/HttpServer.json for webUI/API access
+      - "127.0.0.1:11380:11380"  # API port. Set host to 0.0.0.0 in /data/config/local/HttpServer.json for webUI/API access
       #- "11333:11333"  # Harvester port. Uncomment to allow remote harvesters to connect to the farmer
       #- "11330:11330"  # Farmer port. Uncomment to allow remote farmers to connect to the node
+    environment:
+      MMX_ALLOW_REMOTE: 'false'  # Set to true to allow connections from remote harvesters/farmers
+      MMX_HARVESTER_ENABLED: 'true'  # Set to false to disable local harvester
+      MMX_FARMER_ENABLED: 'true'  # Set to false to disable local farmer
 ```
-
-Note: `- render` in `group_add` might need to be removed, depending on your system.
+Note: Intel ARC support requires a host system running Linux Kernel 6.3 or above
 
 ### NVIDIA GPU
 
@@ -90,17 +104,26 @@ services:
       - /some/path/to/mmx-node:/data
     ports:
       - "11337:11337"  # Node p2p port. Forward your router to this port for peers to be able to connect
-      #- "127.0.0.1:11380:11380"  # API port. Uncomment and set host to 0.0.0.0 in config/local/HttpServer.json for webUI/API access
+      - "127.0.0.1:11380:11380"  # API port. Set host to 0.0.0.0 in /data/config/local/HttpServer.json for webUI/API access
       #- "11333:11333"  # Harvester port. Uncomment to allow remote harvesters to connect to the farmer
       #- "11330:11330"  # Farmer port. Uncomment to allow remote farmers to connect to the node
+    environment:
+      MMX_ALLOW_REMOTE: 'false'  # Set to true to allow connections from remote harvesters/farmers
+      MMX_HARVESTER_ENABLED: 'true'  # Set to false to disable local harvester
+      MMX_FARMER_ENABLED: 'true'  # Set to false to disable local farmer
 ```
 Note: for nvidia you also need the `NVIDIA Container Toolkit` installed on the host, for more info please see: https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html
 
 ## Remote Services
 
-Running a remote harvester or farmer can be done by overwriting the `CMD` of the Dockerfile, for example like this:
+ - Running a remote harvester or farmer can be done by overwriting the `CMD` of the Dockerfile, for example like this:
 
 ### Remote Harvester
+
+ - Set `MMX_ALLOW_REMOTE` to `true` in the node or farmer compose.yml
+ - Make sure port 11333 is uncommented/exposed in the node or farmer compose.yml
+ - Edit the following example with the node or farmers ip address and correct paths
+
 ```yml
 services:
   harvester:
@@ -111,9 +134,14 @@ services:
       - /some/path/to/mmx-node:/data
       - /some/path/to/disks:/disks
 ```
-Note: The harvester must be able to connect to the remote farmer on port 11333. See examples above and below
 
 ### Remote Farmer
+
+ - Set `MMX_ALLOW_REMOTE` to `true` in the node compose.yml
+ - To allow remote harvesters to connect to this farmer set `MMX_ALLOW_REMOTE` to `true` in the example below
+ - Make sure port 11330 is uncommented/exposed in the node compose.yml
+ - Edit the following example with the node ip address and correct data path
+
 ```yml
 services:
   farmer:
@@ -124,5 +152,7 @@ services:
       - /some/path/to/mmx-node:/data
     ports:
       - "11333:11333"  # Farmer listens on this port for remote harvester connections
+    environment:
+      MMX_ALLOW_REMOTE: 'false'  # Set to true to allow connections from remote harvesters
+      MMX_HARVESTER_ENABLED: 'true'  # Set to false to disable local harvester
 ```
-Note: The farmer must be able to connect to the remote node on port 11330. See examples above

--- a/docs/src/content/docs/guides/installation.md
+++ b/docs/src/content/docs/guides/installation.md
@@ -66,7 +66,7 @@ If the build is broken for some reason:
 ```
 This is needed when updating system packages for example.
 
-### Windows via WSL
+## Windows via WSL
 
 To setup Ubuntu 20.04 in WSL on Windows you can follow the tutorial over here: \
 https://docs.microsoft.com/en-us/learn/modules/get-started-with-windows-subsystem-for-linux/
@@ -78,80 +78,6 @@ After that you can follow the normal instructions for Ubuntu 20.04.
 
 To get OpenCL working in WSL:
 https://devblogs.microsoft.com/commandline/oneapi-l0-openvino-and-opencl-coming-to-the-windows-subsystem-for-linux-for-intel-gpus/
-
-## Docker
-
-Docker images are available via `ghcr.io/madmax43v3r/mmx-node` in a few flavours:
-- `edge`: Latest commit cpu only
-- `edge-amd`: Latest commit with amd gpu support
-- `edge-nvidia`: Latest commit with nvidia gpu support
-
-Additionally, each semver tag produces tagged images using the same three flavours from above: `<major>.<minor>.<patch>`, `<major>.<minor>` and `<major>` each with their respective suffix (eg. `0.9.5-amd`). `latest` is set for the latest cpu only semver image.
-
-Each image provides a volume for `/data` which you can override with your own volume or a mapped path to customize the storage location of the node data.
-
-### CPU only
-
-A `docker-compose.yml` for the cpu only node can look like this:
-```yml
-version: '3'
-services:
-  node:
-    image: ghcr.io/madmax43v3r/mmx-node:latest
-    restart: unless-stopped
-    volumes:
-      - /some/path/to/mmx/node/data:/data
-```
-
-### AMD GPU
-
-For amd gpu support please see the following `docker-compose.yml`:
-```yml
-version: '3'
-services:
-  node:
-    image: ghcr.io/madmax43v3r/mmx-node:latest-amd
-    restart: unless-stopped
-    group_add:
-      - video
-      - render
-    devices:
-      - /dev/dri:/dev/dri
-      - /dev/kfd:/dev/kfd
-    volumes:
-      - /some/path/to/mmx/node/data:/data
-```
-Note: `- render` in `group_add` might need to be removed, depending on your system.
-
-### NVIDIA GPU
-
-For nvidia gpu support please see the following `docker-compose.yml`:
-```yml
-version: '3'
-services:
-  node:
-    image: ghcr.io/madmax43v3r/mmx-node:latest-nvidia
-    restart: unless-stopped
-    runtime: nvidia
-    volumes:
-      - /some/path/to/mmx/node/data:/data
-```
-Note: for nvidia you also need the `NVIDIA Container Toolkit` installed on the host, for more info please see: https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html#docker
-
-### Remote harvester
-
-Running a remote harvester is done by overwriting the `CMD` of the Dockerfile, for example like this:
-```yml
-version: '3'
-services:
-  harvester:
-    image: ghcr.io/madmax43v3r/mmx-node:latest
-    restart: unless-stopped
-    volumes:
-      - /some/path/to/mmx/node/data:/data
-      - /some/path/to/disks:/disks
-    command: './run_harvester.sh -n <some ip or hostname here>'
-```
 
 ## Custom storage path
 


### PR DESCRIPTION
Moved docker out of the main install guide to it's own page and fine tuned a lot of the examples