### PR TITLE
Links, minor plotting info and vdf opencl changes

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -17,6 +17,7 @@ export default defineConfig({
 				baseUrl: 'https://github.com/madMAx43v3r/mmx-node/edit/master/docs'
 			},
 			sidebar: [
+				{	label: 'Homepage', link: 'https://mmx.network/'},
 				{
 					label: 'Guides',
 					autogenerate: { directory: 'guides' },

--- a/docs/src/content/docs/faq/plotting.md
+++ b/docs/src/content/docs/faq/plotting.md
@@ -23,7 +23,9 @@ For mainnet, k29 to k32 are supported.
 That depends on what kind of hardware you already have. The minimum k size of k29 requires 64GB to plot all in RAM. If you only have 32GB RAM and huge/fast NVMe, you can try plotting in partial RAM. Or you can disk plot k32s.
 If you have 128GB or 256GB RAM, you should try to plot the largest k size possible (k30 and k31 all in RAM, respectively).
 
-With the latest new MMX plot format, there is probably 3% difference in non-compressed and C15 (maximum compression). So it's not really worth the extra compute for just a few GB difference. Personally, I think C1-C5 is where it matters. I recommend C3 if you're harvesting with a Pi4 and have farm size < 300TB. If you run dual Xeon v3/v4, you can try C5 or C6. 
+With maximum compression level currently supported by the MMX plotter, there is roughly 3% difference between non-compressed and C15. So it's not really worth the extra compute for just a few GB difference. Personally, I think C1-C5 is where it matters. I recommend C3 if you're harvesting with a Pi4 and have farm size < 300TB. If you run dual Xeon v3/v4, you can try C5 or C6. 
+
+You can run the [benchmark](/guides/mmx-plotter/#benchmark) tool to see what compression level your hardware can handle or read the full [Plotting Guide](/guides/mmx-plotter/).
 
 ### _What are the final plot sizes for k29 to k32, C0 to C15 ?_
 Please refer to this spreadsheet, switch to the "Miscellaneous" tab.
@@ -59,3 +61,6 @@ Current plotter use the RAM natively, there is no need to assign RAM disk or tmp
 | K32  |  320   |     446    |      246      |     177     |
 
 **Note: The numbers above are just an approximation.**
+
+### _Can I make pooling plots?_
+Yes, you can create poolable plots using a plotnft contract. You first have to create the plotnft contract which requires about 0.1 MMX. You can then use the plotnft contract address when creating the plots using the `-c <contract_address>` option. By default the plotnft will be set to solo. There are currently no public pools operating on mainnet.

--- a/docs/src/content/docs/guides/getting-started.md
+++ b/docs/src/content/docs/guides/getting-started.md
@@ -3,6 +3,7 @@ title: Getting Started
 description: Getting started with MMX.
 i18nReady: true
 ---
+**[Install](../installation/) MMX-Node.**
 
 ## GUI
 The native GUI can be opened by searching for `MMX Node` (when installed via binary package).
@@ -188,6 +189,8 @@ This is needed if for some reason the node forked from the network. Just subtrac
 
 ## Plotting
 
+**For an in depth guide on plotting, see** [Plotting Guide](../mmx-plotter/).
+
 To get the farmer key for plotting:
 ```
 mmx wallet keys [-j index]
@@ -210,13 +213,11 @@ Example Partial RAM: `./mmx_cuda_plot_k30 -C 5 -n -1 -2 /mnt/tmp_ssd/ -d <dst> -
 
 Example Disk Mode: `./mmx_cuda_plot_k30 -C 5 -n -1 -3 /mnt/tmp_ssd/ -d <dst> -f <farmer_key>`
 
-Usage is the same as for Gigahorse (https://github.com/madMAx43v3r/chia-gigahorse/tree/master/cuda-plotter), just without `-p` pool key.
-
-If you have a fast CPU ([passmark benchmark](https://www.cpubenchmark.net) > 5000 points) you can use `-C 10` for HDD plots.
+If you would like to use compressed plots, it is recommended that you run the mmx_posbench tool to benchmark your hardware.
 
 To create SSD plots (for farming on SSDs) add `--ssd` to the command and use `-C 0`. SSD plots are 250% more efficient but cannot be farmed on HDDs. They have higher CPU load to farm, hence it's recommended to plot uncompressed.
 
-The minimum k-size for mainnet will be k29, for testnet it is k26. The plots from testnet11 and onwards can be reused for mainnet later.
+The minimum k-size for mainnet is k29, the maximum k-size is k32.
 
 To add a plot directory add the path to `plot_dirs` array in `config/local/Harvester.json`, for example:
 ```

--- a/docs/src/content/docs/guides/mmx-plotter.mdx
+++ b/docs/src/content/docs/guides/mmx-plotter.mdx
@@ -25,26 +25,26 @@ C10 can be farmed on most modern CPUs while still giving a gain of 3%. Larger ca
 <Aside>Full RAM, and Partial RAM refer to plotting modes. Disk space is what is needed by `-2` with partial RAM plotting. When using full disk mode plotting, temp space required for `-3` is the same as Partial RAM requirements. If `-3` and `-2` are the same drive, use the Full RAM space as a reference.</Aside>
 <Aside type="caution">The RAM Requirements above were tested to work on linux. Due to quirks of memory usage on Windows OS, it may not be possible to plot k31 in partial ram on a system with 128gb of ram.</Aside>
 
-### Compression
+## Compression
 The MMX CUDA Plotter supports compression levels C0 to C15. Farming compressed plots is currently only supported on CPU.
 However recomputing a full proof on HDD plots is only required when a good enough quality has been found, either to make a block or to make a partial.
 GPU recompute would only add a few extra percent of gains, at the cost of needing a (big) GPU to sit idle most of the time (in case of HDD plots).
 GPU recompute for farming lots of (uncompressed) SSD plots is planned, as this is the only use case where it makes sense.
 Since SSD plots always need to recompute the proof output hash (quality), meaning the compute load is proportional to number of plots.
 
-#### HDD Plots
+### HDD Plots
 C15 is _possible_ to farm on CPU, but only with ~64 cores or more. It is not recommended to use C15 as the gain over C10 is minimal (1.5%).
 C10-C12 can be handled by most modern CPUs. C5 can be farmed on almost any CPU, with minimal power draw.
 When making NFT plots, it is recommended to use a lower C level (3-5 levels lower) since more proofs need to be computed when pooling (one for each partial).
 The compute load when farming HDD plots is independent of the number of plots. The challenge is computing a full proof fast enough to make a block or partial in time.
 
-#### SSD Plots
+### SSD Plots
 SSD plots are 2.5x smaller than HDD plots. They cannot be farmed on HDDs (even in a RAID array) due to the high IOPS required to farm them (proportional to plot count).
 The CPU load to farm SSD plots is already quite high with C0, as such C0 is recommended when making SSD plots. Higher k-size reduces CPU and IOPS load.
 As such the most efficient SSD plots are k32 C0, with k29 having 8x higher CPU and IOPS load. k32 C3 is equal to k29 C0 in terms of CPU load.
 Farming 1024 uncompressed SSD plots is the same compute load as computing a single C10 full proof.
 
-#### Benchmark
+### Benchmark
 Before plotting with compression a benchmark should be performed to check if your system can handle it:
 ```
 mmx_posbench -k 31 -C 10				# to benchmark k31 C10

--- a/docs/src/content/docs/guides/optimize-vdf.md
+++ b/docs/src/content/docs/guides/optimize-vdf.md
@@ -20,7 +20,7 @@ Note: During initial blockchain sync, CPU usage can be high in any case.
 Example Hardware and times spreadsheet: https://docs.google.com/spreadsheets/d/1NlK-dq7vCbX4NHzrOloyy4ylLW-fdXjuT8468__SF64/edit?pli=1&gid=618383284#gid=618383284
 
 ## OpenCL for Intel iGPUs
-Intel iGPUs prior to 11th gen will most likely not be sufficient for mainnet.
+Intel iGPUs prior to 11th gen are not sufficient for mainnet. Intel's desktop iGPUs have much fewer compute units than their mobile counterparts, so only the mobile SKUs in laptops/mini-PCs will be suitable for OpenCL VDF verify. 11th gen and newer desktop CPUs with the SHA instruction set can get decent performance on the CPU cores without OpenCL.
 
 Ubuntu 20.04, 21.04
 ```
@@ -75,7 +75,9 @@ Windows: https://google.com/search?q=amd+graphics+driver+download
 
 ## OpenCL for Nvidia GPUs
 
-Install Nvidia drivers.
+Due to the massive generational leap in compute performance, the Maxwell generation (900 series Geforce, M-series and some K-series Quadro) should be the minimum consideration for Nvidia GPUs. 
+
+Install Nvidia drivers:
 
 ### Ubuntu
 

--- a/docs/src/styles/style.css
+++ b/docs/src/styles/style.css
@@ -1,9 +1,16 @@
 :root {
     --sl-content-width: 80%;
+	
     --sl-nav-gap: 5rem;
     .content-panel .sl-container {
         margin-left: 5rem;
     }
+	@media (max-width: 800px) {
+		--sl-content-width: 100%;
+		.content-panel .sl-container {
+			margin-left: 0;
+		};
+	}
 	--mmx-color-purple: hsl(262, 36%, 36%);
 
     --sl-color-white: hsl(0, 0%, 100%); /* “white” */


### PR DESCRIPTION
Added some links, main website landing page to left sidebar, some internal links between docs after the getting-started re-org.

Dropped the headings for "Compression" down a level so they would appear in the right sidebar:
![image](https://github.com/user-attachments/assets/76f40f76-229b-4ca7-b085-f9d83452da20)
before
![image](https://github.com/user-attachments/assets/08ebb4f2-6344-4f10-96d3-4e1c7ad6c54c)
after

Added a pooling question to plotting faq, didn't have time today to write up a pooling/plotnft doc to link to.
