### PR TITLE
Tuned frontpage MMX Docs (suggestions)

### DIFF
--- a/docs/src/components/BottomWaves.astro
+++ b/docs/src/components/BottomWaves.astro
@@ -37,6 +37,7 @@
     }
     .shape-fill {
         fill: var(--mmx-color-purple);
+        filter: grayscale(25%);
     }
     
 </style>

--- a/docs/src/components/LinkCard.astro
+++ b/docs/src/components/LinkCard.astro
@@ -25,7 +25,7 @@ const { icon, title, url } = Astro.props;
 	.sl-link-card {
 		--sl-card-border: var(--sl-color-purple);
 		--sl-card-bg: var(--sl-color-purple-low);
-		border: 1px solid var(--sl-color-gray-5);
+		border: 2px solid var(--sl-color-gray-5);
         border-radius: 0.5rem;
 		background-color: var(--sl-color-black);
 		padding: clamp(1rem, calc(0.125rem + 3vw), 2rem);
@@ -38,6 +38,7 @@ const { icon, title, url } = Astro.props;
         font-size: 1.5rem;
         margin-left: auto;
         color: var(--sl-color-gray-2);
+	flex: 0 0 1em;
     } 
     a {
 		text-decoration: none;
@@ -79,10 +80,11 @@ const { icon, title, url } = Astro.props;
         flex-direction: column;
     }
 	.card .icon {
-		border: 1px solid var(--sl-card-border);
+		border: 2px solid var(--sl-card-border);
 		background-color: var(--sl-card-bg);
 		padding: 0.2em;
 		border-radius: 0.25rem;
+		flex: 0 0 1em;
 	}
 	.card .body {
 		margin: 0;

--- a/docs/src/components/Navbar.astro
+++ b/docs/src/components/Navbar.astro
@@ -7,6 +7,7 @@ import { Icon } from '@astrojs/starlight/components';
         <a class="navbar-item" href="/">
             <img src="/images/mmx_rect.png" alt="MMX logo" class="logo" />
         </a>
+        <div class="navbar-text">Documentation</div>
         <div class="navbar-spacer"></div>
         <div class="navbar-end">
             <a class="navbar-item" href="https://mmx.network/"><Icon name="star" class="icon" size="1.33em"></Icon></a>
@@ -24,7 +25,7 @@ import { Icon } from '@astrojs/starlight/components';
         left: 0;
         width: 100%;
         height: 4rem;
-        background-color: hsl(224, 14%, 16%);
+	background-color: var(--sl-color-gray-6);
         box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
         z-index: 1000;
     }
@@ -41,19 +42,30 @@ import { Icon } from '@astrojs/starlight/components';
     }
 
     .navbar-item {
-        color: hsl(262, 36%, 79%);
+        color: var(--sl-color-white);
         text-decoration: none;
         margin-left: 1rem;
         font-size: 1.2rem;
         height: 100%;
     }
+
+    .navbar-text {
+        color: var(--sl-color-white);
+        text-decoration: none;
+        margin-left: 1rem;
+        font-size: 1.75rem;
+        height: 100%;
+        line-height: 4rem;
+        font-weight: 600;
+    }
+
     .navbar-end {
         display: flex;
         align-items: center;
     }
 
     .navbar-item:hover {
-        color: hsl(262, 36%, 36%);
+	color: var(--sl-color-accent-high);
     }
 
     .navbar-spacer {
@@ -74,7 +86,12 @@ import { Icon } from '@astrojs/starlight/components';
         .navbar-item {
             padding: 0 0.5rem;
             font-size: 1.5rem;
-            
+        }
+
+        .navbar-text {
+            padding: 0 0.25rem;
+	    line-height: 5rem;
+            font-size: 2.18rem;
         }
     }
 </style>

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -13,7 +13,6 @@ import '../styles/style.css';
 <div class="main">
     <div class="top-spacer"></div>
     <div class="hero">
-        <h1>MMX Documentation</h1>
     <div class="cardgrid"><CardGrid>
         <LinkCard title="Guides" icon="pencil" url="guides/getting-started/">
             <p class="desc">How to use MMX</p>

--- a/docs/src/styles/style.css
+++ b/docs/src/styles/style.css
@@ -20,16 +20,16 @@
 			margin-left: 0;
 		};
 	}
-	--mmx-color-purple: hsl(262, 36%, 36%);
+	--mmx-color-purple: hsl(267, 60%, 39%);
 
-    --sl-color-white: hsl(0, 0%, 100%); /* “white” */
-	--sl-color-gray-1: hsl(224, 20%, 94%);
-	--sl-color-gray-2: hsl(224, 6%, 77%);
-	--sl-color-gray-3: hsl(224, 6%, 56%);
-	--sl-color-gray-4: hsl(224, 7%, 36%);
-	--sl-color-gray-5: hsl(224, 10%, 23%);
-	--sl-color-gray-6: hsl(224, 14%, 16%);
-	--sl-color-black: hsl(224, 10%, 10%);
+	--sl-color-white: hsl(0, 0%, 100%); /* “white” */
+	--sl-color-gray-1: hsl(232, 0%, 94%);
+	--sl-color-gray-2: hsl(232, 0%, 77%);
+	--sl-color-gray-3: hsl(232, 0%, 56%);
+	--sl-color-gray-4: hsl(232, 0%, 36%);
+	--sl-color-gray-5: hsl(232, 0%, 23%);
+	--sl-color-gray-6: hsl(232, 0%, 16%);
+	--sl-color-black: hsl(232, 0%, 7%);
 
 	--sl-hue-orange: 41;
 	--sl-color-orange-low: hsl(var(--sl-hue-orange), 39%, 22%);


### PR DESCRIPTION
PR for tuned elements of MMX Docs frontpage (suggestions)

Changes:
- Changed 'gray' varants to align with other MMX dark editions (Homepage, Explorer, WebUI)
- Changed MMX 'purple' to latest, RGB: 94,40,159 vs 83,59,125
- Toned 'waves' down 25% in intensity, too 'extreme' if all-in new purple
- Border of cards 2px vs existing1px too 'slim', especially round corners
- Fix to make icons 'static' size in certain situation, look (i)
- Fix to make arrows 'static' size in certain situation, look arrows
- White navbar icons, light-blue-accent when hover/selected
- **Maybe 'Documentation' in navbar, eliminate 'MMX Documentation' text** (below navbar)

**Questions:**
- Point out any elements that works, or want adjustments
- **Before any possible merge, need to adjust/agree on 'Documentation' or not in navbar**
  - Can eliminate 'MMX Documentation' below navbar, use 'Docs' in navbar, keep as-is, or any combination
  - My own preference would be the new 'Documentation' in navbar, and eliminate 'MMX Documentation' below

**Compare changes in 2x screenshots below**, by switching between them (1st: changes/new, 2nd: current/old):

<img src="https://github.com/user-attachments/assets/4ff8877a-a0e4-429e-b1ea-ed1a978bd1df" width="300" />

<img src="https://github.com/user-attachments/assets/cd022645-3b0d-4f59-81f2-03a7c7c3d139" width="300" />
