### PR TITLE
Edit docs Syntax Highlight

### DIFF
--- a/docs/src/content/docs/faq/mmx-node.md
+++ b/docs/src/content/docs/faq/mmx-node.md
@@ -16,7 +16,7 @@ Are you sure you have read the installation wiki linked above? It says to update
 Check that VDF verification is done via GPU. Disable Timelord when enabled by accident.
 
 On Linux make sure to be in the `video` and or `render` group (depends on distribution) to be able to access a GPU:
-```
+```bash frame="none"
 sudo adduser $USER video
 sudo adduser $USER render
 ```
@@ -57,7 +57,7 @@ Stop the node, then delete the `testnetX` folder and restart node. This will syn
 Adding plot directories is now possible in the GUI settings page.
 
 Alternatively, open `config/local/Harvester.json` with a text editor. Follow the syntax below:
-```
+```json
 {
   "reload_interval": 3600,
   "farm_virtual_plots": true,
@@ -72,7 +72,7 @@ Alternatively, open `config/local/Harvester.json` with a text editor. Follow the
 }
 ```
 You may also put everything on 1 line if it helps you to see all the plot drives/folders:
-```
+```json
 "plot_dirs": ["D:/", "E:/", "F:/", "G:/", "H:/", "I:/", "J:/", "K:/", "L:/"]
 ```
 Backward slash "`\`" is not supported, so forward slash "`/`" must be used.

--- a/docs/src/content/docs/faq/plotting.md
+++ b/docs/src/content/docs/faq/plotting.md
@@ -8,7 +8,7 @@ description: Frequently asked questions about plotting.
 At the end of the command, add `2>&1 | tee /home/user/desired_path/$(uuid).log;`
 
 Example:
-```
+```bash frame="none"
 ./mmx_cuda_plot -f [insert your public farmer key here] -p [insert your pool key here]  -t /mnt/NVME/Temp/ -2 /mnt/ramdisk/ -d /mnt/NVME/Temp/ -C 3 -S 2  -n 18 2>&1 | tee /home/user/desired_path/(filename).log;
 ```
 

--- a/docs/src/content/docs/faq/vdf.md
+++ b/docs/src/content/docs/faq/vdf.md
@@ -46,7 +46,9 @@ https://opencl.gpuinfo.org/download.php
 Perform OpenCL hardware diagnostic/info tool and get `cl_platform_name`
 
 Then run the node with the GPU you want OpenCL to be done with:
-`./run_node.sh --opencl.platform "name"`
+```bash frame="none"
+./run_node.sh --opencl.platform "name"
+```
 
 For Nvidia, it's "NVIDIA CUDA"
 
@@ -57,13 +59,19 @@ For Intel, it's "Intel(R) OpenCL"
 For a more permanent solution (or in Windows), you can also create a file named `platform` in ~/config/local/opencl/ and put the platform name in there. Please include the quotes "".
 
 If you have an AMD APU and another AMD discrete GPU with the same platform name, you can select which OpenCL device to use:
-`./run_node.sh --Node.opencl_device 0/1`
+```bash frame="none"
+./run_node.sh --Node.opencl_device 0/1
+```
 
 Or if you have an AMD APU and a mix of discrete AMD/Nvidia GPUs, you can combine the parameters. Example:
-`./run_node.sh --Node.opencl_device 2 --opencl.platform "NVIDIA CUDA"`
+```bash frame="none"
+./run_node.sh --Node.opencl_device 2 --opencl.platform "NVIDIA CUDA"
+```
 
 If you want to force use your CPU to do VDFs, while having a GPU installed in your computer, you can run this command:
-`./run_node.sh --Node.opencl_device -1`
+```bash frame="none"
+./run_node.sh --Node.opencl_device -1
+```
 
 ### _How do I know if MMX is using my GPU to do VDFs?_
 Start a node, look for this line:

--- a/docs/src/content/docs/guides/getting-started.md
+++ b/docs/src/content/docs/guides/getting-started.md
@@ -9,7 +9,7 @@ i18nReady: true
 The native GUI can be opened by searching for `MMX Node` (when installed via binary package).
 
 In case of compiling from source:
-```
+```bash frame="none"
 ./run_node.sh --gui      # includes wallet and farmer
 ./run_wallet.sh --gui    # remote wallet (connect to another node)
 ```
@@ -24,7 +24,7 @@ In case of a binary package install, the password will be in `~/.mmx/PASSWD`. By
 ## CLI
 
 When compiled from source:
-```
+```bash frame="none"
 cd mmx-node
 source ./activate.sh
 ```
@@ -34,7 +34,7 @@ Note: A new wallet can also be created in the GUI.
 
 ### Creating a Wallet (offline)
 
-```
+```bash frame="none"
 mmx wallet create [-f filename] [--with-passphrase]
 ```
 
@@ -43,19 +43,19 @@ The file name argument is optional. By default it is `wallet.dat`, which will be
 Additional wallets need to be added to `key_files` array in `config/local/Wallet.json`.
 
 To use a passphrase, specify `--with-passphrase` without the actual passphrase:
-```
-$ mmx wallet create --with-passphrase
+```bash frame="none"
+mmx wallet create --with-passphrase
 Passphrase: <type here>
 ```
 
 To create a wallet with a known mnemonic seed, specify `--with-mnemonic` without the actual words:
-```
+```bash frame="none"
 mmx wallet create --with-mnemonic
 Mnemonic: word1 word2 ... <enter>
 ```
 
 To get the mnemonic seed from a wallet (with Node / Wallet already running):
-```
+```bash frame="none"
 mmx wallet get seed [-j index]
 ```
 
@@ -64,7 +64,7 @@ Note: A Node / Wallet restart is needed to pick up a new wallet.
 ### Creating a Wallet (online)
 
 With a running Node / Wallet:
-```
+```bash frame="none"
 mmx wallet new [name] [--with-mnemonic] [--with-passphrase] [-N <num_addresses>]
 ```
 All parameters are optional. The new wallet can be seen with `mmx wallet accounts` (last entry).
@@ -77,7 +77,7 @@ To use a passphrase, specify `--with-passphrase` without the actual passphrase. 
 
 First perform the installation and setup steps, then:
 
-```
+```bash frame="none"
 ./run_node.sh
 ```
 You can enable port forwarding on TCP port 11337, if you want to help out the network and accept incoming connections.
@@ -89,7 +89,7 @@ Note: Any config changes require a node restart to become effective.
 #### Custom Farmer Reward Address
 
 Create / Edit file `config/local/Farmer.json`:
-```
+```json
 {
 	"reward_addr": "mmx1..."
 }
@@ -99,7 +99,7 @@ By default the first address of the first wallet is used.
 #### Custom Timelord Reward Address
 
 Create / Edit file `config/local/TimeLord.json`:
-```
+```json
 {
 	"reward_addr": "mmx1..."
 }
@@ -108,21 +108,21 @@ Create / Edit file `config/local/TimeLord.json`:
 #### Fixed Node Peers
 
 Create / Edit file `config/local/Router.json`:
-```
+```json
 {
 	"fixed_peers": ["192.168.0.123", "more"]
 }
 ```
 
 #### Enable Timelord
-```
+```bash frame="none"
 echo true > config/local/timelord
 ```
 
 #### CUDA Settings
 
 Create / Edit `config/local/cuda.json`:
-```
+```json
 {
 	"enable": true,
 	"devices": [0, 1, ...]
@@ -133,7 +133,7 @@ Empty device list = use all devices. Device indices start at 0. CUDA is enabled 
 #### Custom home directory
 
 To set a custom storage path for the blockchain DB, wallet files, etc:
-```
+```bash frame="none"
 export MMX_HOME=/your/path/
 ```
 Wallet files will end up in `MMX_HOME`, everything else in `mainnet` subfolder.
@@ -145,7 +145,7 @@ Note: A trailing `/` in the path is required.
 #### Custom data directory
 
 To store the DB in a custom directory you can set environment variable `MMX_DATA` (for example):
-```
+```bash frame="none"
 export MMX_DATA=/mnt/mmx_data/
 ```
 A node restart is required. Optionally the `mainnet` folder can be copied to the new `MMX_DATA` path (after stopping the node), to avoid having to sync from scratch again.
@@ -156,7 +156,7 @@ Note: A trailing `/` in the path is required.
 
 If you have a slow internet connection or want to reduce traffic in general you can lower the number of connections in `config/local/Router.json`.
 For example to run at the bare recommended minimum:
-```
+```json
 {
 	"num_peers_out": 4,
 	"max_connections": 4
@@ -171,11 +171,10 @@ However this will hurt the network, so please only disable it if absolutely nece
 ### Running in background
 
 To run a node in the background you can enter a `screen` session:
-```
-screen -S node
-(start node as above)
-<Ctrl+A> + D (to detach)
-screen -r node (to attach again)
+```bash frame="none"
+screen -S node    # start node as above
+# <Ctrl+A> + D    # to detach
+screen -r node    # to attach again
 ```
 
 ### Recover from forking
@@ -189,7 +188,7 @@ This is needed if for some reason the node forked from the network. Just subtrac
 **For an in depth guide on plotting, see** [Plotting Guide](../mmx-plotter/).
 
 To get the farmer key for plotting:
-```
+```bash frame="none"
 mmx wallet keys [-j index]
 ```
 The node needs to be running for this command to work. (`-j` to specify the index of a non-default wallet)
@@ -204,11 +203,14 @@ Download CUDA plotter here: https://github.com/madMAx43v3r/mmx-binaries/tree/mas
 
 There is no CPU plotter anymore for the new format, because it would be too inefficient. Any old Nvidia GPU will do, Maxwell or newer.
 
-Example Full RAM: `./mmx_cuda_plot_k30 -C 5 -n -1 -t /mnt/tmp_ssd/ -d <dst> -f <farmer_key>`
-
-Example Partial RAM: `./mmx_cuda_plot_k30 -C 5 -n -1 -2 /mnt/tmp_ssd/ -d <dst> -f <farmer_key>`
-
-Example Disk Mode: `./mmx_cuda_plot_k30 -C 5 -n -1 -3 /mnt/tmp_ssd/ -d <dst> -f <farmer_key>`
+```bash frame="none"
+# Example Full RAM:
+./mmx_cuda_plot_k30 -C 5 -n -1 -t /mnt/tmp_ssd/ -d <dst> -f <farmer_key>
+# Example Partial RAM:
+./mmx_cuda_plot_k30 -C 5 -n -1 -2 /mnt/tmp_ssd/ -d <dst> -f <farmer_key>
+# Example Disk Mode:
+./mmx_cuda_plot_k30 -C 5 -n -1 -3 /mnt/tmp_ssd/ -d <dst> -f <farmer_key>
+```
 
 If you would like to use compressed plots, it is recommended that you run the mmx_posbench tool to benchmark your hardware.
 
@@ -217,7 +219,7 @@ To create SSD plots (for farming on SSDs) add `--ssd` to the command and use `-C
 The minimum k-size for mainnet is k29, the maximum k-size is k32.
 
 To add a plot directory add the path to `plot_dirs` array in `config/local/Harvester.json`, for example:
-```
+```json
 {
 	"plot_dirs": [
 		"/mnt/drive1/plots/",

--- a/docs/src/content/docs/guides/installation.md
+++ b/docs/src/content/docs/guides/installation.md
@@ -15,7 +15,7 @@ Scroll down to "Other Tools" here: https://visualstudio.microsoft.com/downloads/
 Linux binary packages are available here: https://github.com/madMAx43v3r/mmx-node/releases
 
 To install a binary package:
-```
+```bash frame="none"
 sudo apt install ~/Downloads/mmx-node-1.1.7-amd64-ubuntu-20.04.deb
 ```
 This will automatically install dependencies as well.
@@ -25,7 +25,7 @@ When no matching package is found, continue below to build from source.
 ### Dependencies
 
 Ubuntu Linux:
-```
+```bash frame="none"
 sudo apt update
 sudo apt install git cmake build-essential automake libtool pkg-config curl libminiupnpc-dev libjemalloc-dev libzstd-dev zlib1g-dev ocl-icd-opencl-dev clinfo screen
 # Optional dependencies:
@@ -34,7 +34,7 @@ sudo apt install nvidia-cuda-toolkit  # for CUDA compute (farming)
 ```
 
 Arch Linux:
-```
+```bash frame="none"
 sudo pacman -Syu
 sudo pacman -S base-devel git cmake curl miniupnpc jemalloc zstd zlib opencl-headers ocl-icd clinfo screen
 # Optional dependencies:
@@ -43,7 +43,7 @@ sudo pacman -S cuda  # for CUDA compute (farming)
 ```
 
 Fedora Linux:
-```
+```bash frame="none"
 sudo yum install kernel-devel git cmake automake libtool curl gcc gcc-c++ miniupnpc-devel jemalloc-devel ocl-icd-devel zlib-ng-devel zstd clinfo screen
 # Optional dependencies:
 sudo yum install qt5-qtwebengine-devel  # for native GUI
@@ -53,7 +53,7 @@ Note: To enable CUDA support, CUDA needs to be installed: https://developer.nvid
 
 ### Building from Source
 
-```
+```bash frame="none"
 git clone https://github.com/madMAx43v3r/mmx-node.git
 cd mmx-node
 ./update.sh
@@ -64,14 +64,14 @@ To disable CUDA support: `./update.sh -D DISABLE_CUDA=1` \
 These settings are stored, until the next `./clean_all.sh`, so only needs to be specified once. To enable again, set the config to `0`.
 
 To update to latest version:
-```
+```bash frame="none"
 ./update.sh
 ```
 
 ### Rebuilding
 
 If the build is broken for some reason:
-```
+```bash frame="none"
 ./clean_all.sh
 ./update.sh
 ```

--- a/docs/src/content/docs/guides/mmx-plotter.mdx
+++ b/docs/src/content/docs/guides/mmx-plotter.mdx
@@ -46,10 +46,10 @@ Farming 1024 uncompressed SSD plots is the same compute load as computing a sing
 
 ### Benchmark
 Before plotting with compression a benchmark should be performed to check if your system can handle it:
-```
-mmx_posbench -k 31 -C 10				# to benchmark k31 C10
-mmx_posbench --cuda 0 -k 31 -C 10		# to benchmark on CPU
-mmx_posbench --devices 1 2 -k 31 -C 10	# to select specific CUDA devices (starting at 0)
+```bash frame="none"
+mmx_posbench -k 31 -C 10                  # to benchmark k31 C10
+mmx_posbench --cuda 0 -k 31 -C 10         # to benchmark on CPU
+mmx_posbench --devices 1 2 -k 31 -C 10    # to select specific CUDA devices (starting at 0)
 ```
 
 ## Creating Plots
@@ -61,25 +61,25 @@ To use the plotter via command line, navigate to the directory containing the pl
 <Tabs>
     <TabItem label="Full RAM">
         For full Ram plotting, `-t` is used to temporarily store the the finished plot before moving it to the destination `-d`, RAM is used for the entire plotting process.
-        ```
+        ```bash frame="none"
         ./mmx_cuda_plot_k30 -C 5 -n -1 -t /mnt/tmp_ssd/ -d /mnt/farmdrive/ -f <farmer_key>
         ```
     </TabItem>
     <TabItem label="Partial RAM">
         For partial RAM plotting, `-2` is used to store temporary working files before moving the finished plot to `-t` and then to `-d`. RAM is used for the most write intensive parts of the plotting process. If `-t` is not specified, the plotter will set the `-t` argument to the same value as `-2`.
-        ```
+        ```bash frame="none"
         ./mmx_cuda_plot_k30 -C 5 -n -1 -t /mnt/tmp_ssd/ -2 /mnt/tmp_ssd/ -d /mnt/farmdrive/ -f <farmer_key>
         ```
     </TabItem>
     <TabItem label="Disk Mode">
         For disk mode plotting, `-3` takes the place of RAM and is used for write intensive temporary files. You can use a different drive for `-2` if desired, the faster of the two drives should be used for `-3`. If `-2` or `-t` are not specified, the plotter will set the value of both to the same value as `-3`.
-        ```
+        ```bash frame="none"
         ./mmx_cuda_plot_k30 -C 5 -n -1 -t /mnt/tmp_ssd/ -2 /mnt/tmp_ssd/ -3 /mnt/tmp_ssd/ -d /mnt/farmdrive/ -f <farmer_key>
         ```
     </TabItem>
 </Tabs>
 To send finished plots to multiple destinations, use the `-d` argument multiple times. For example:
-```
+```bash frame="none"
 ./mmx_cuda_plot_k30 -C 5 -n -1 -t /mnt/tmp_ssd/ -d /mnt/farmdrive1/ -d /mnt/farmdrive2/ -f <farmer_key>
 ```
 <Aside>To simplify sending to multiple destinations over a network, you can use [plot-sink](https://github.com/madMAx43v3r/chia-gigahorse/tree/master/plot-sink).</Aside>
@@ -93,17 +93,13 @@ Usage:
 
   -C, --level arg      Compression level (0 to 15)
       --ssd            Make SSD plots
-  -n, --count arg      Number of plots to create (default = 1, unlimited =
-                       -1)
+  -n, --count arg      Number of plots to create (default = 1, unlimited = -1)
   -g, --device arg     CUDA device (default = 0)
   -r, --ndevices arg   Number of CUDA devices (default = 1)
-  -t, --tmpdir arg     Temporary directories for plot storage (default =
-                       $PWD)
-  -2, --tmpdir2 arg    Temporary directory 2 for partial RAM / disk mode
-                       (default = @RAM)
+  -t, --tmpdir arg     Temporary directories for plot storage (default = $PWD)
+  -2, --tmpdir2 arg    Temporary directory 2 for partial RAM / disk mode (default = @RAM)
   -3, --tmpdir3 arg    Temporary directory 3 for disk mode (default = @RAM)
-  -d, --finaldir arg   Final destinations (default = <tmpdir>, remote =
-                       @HOST)
+  -d, --finaldir arg   Final destinations (default = <tmpdir>, remote = @HOST)
   -z, --dstport arg    Destination port for remote copy (default = 1337)
   -w, --waitforcopy    Wait for copy to start next plot
   -c, --contract arg   Pool Contract Address (62 chars)
@@ -112,10 +108,8 @@ Usage:
   -B, --chunksize arg  Bucket chunk size in MiB (default = 16, 1 to 256)
   -Q, --maxtmp arg     Max number of plots to cache in tmpdir (default = -1)
   -A, --copylimit arg  Max number of parallel copies in total (default = -1)
-  -W, --maxcopy arg    Max number of parallel copies to same HDD (default =
-                       1, unlimited = -1)
-  -M, --memory arg     Max shared / pinned memory in GiB (default =
-                       unlimited)
+  -W, --maxcopy arg    Max number of parallel copies to same HDD (default = 1, unlimited = -1)
+  -M, --memory arg     Max shared / pinned memory in GiB (default = unlimited)
       --version        Print version
   -h, --help           Print help
-  ```
+```

--- a/docs/src/content/docs/guides/optimize-vdf.md
+++ b/docs/src/content/docs/guides/optimize-vdf.md
@@ -23,12 +23,12 @@ Example Hardware and times spreadsheet: https://docs.google.com/spreadsheets/d/1
 Intel iGPUs prior to 11th gen are not sufficient for mainnet. Intel's desktop iGPUs have much fewer compute units than their mobile counterparts, so only the mobile SKUs in laptops/mini-PCs will be suitable for OpenCL VDF verify. 11th gen and newer desktop CPUs with the SHA instruction set can get decent performance on the CPU cores without OpenCL.
 
 Ubuntu 20.04, 21.04
-```
+```bash frame="none"
 sudo apt install intel-opencl-icd
 ```
 
 Ubuntu ppa for 18.04, 20.04, 21.04
-```
+```bash frame="none"
 sudo add-apt-repository ppa:intel-opencl/intel-opencl
 sudo apt update
 sudo apt install intel-opencl-icd
@@ -50,24 +50,24 @@ Change directory to the Download folder and install with `sudo dpkg -i amdgpu-in
 `sudo apt install rocm-opencl`
 
 Follow on-screen instructions and then run:
-```
+```bash frame="none"
 sudo apt update
 sudo apt upgrade
 ```
 
 Arch Linux:
-```
+```bash frame="none"
 sudo pacman -S opencl-amd
 ```
 
 Mesa drivers with opencl drivers do seem to work, but performance is very poor (VDF verification >4x longer).\
 To install mesa drivers:\
 Ubuntu:
-```
+```bash frame="none"
 sudo apt install mesa-opencl-icd
 ```
 Arch:
-```
+```bash frame="none"
 sudo pacman -S mesa mesa-utils opencl-mesa
 ```
 
@@ -81,7 +81,7 @@ Install Nvidia drivers:
 
 ### Ubuntu
 
-```
+```bash frame="none"
 sudo apt install nvidia-driver-470
 sudo apt install nvidia-driver-565
 ```
@@ -89,15 +89,15 @@ Version 470 still works with older Kepler cards like a Quadro K2000.
 Use latest version for newer GPUs.
 
 ### Arch Linux
-```
+```bash frame="none"
 sudo pacman -S nvidia nvidia-utils opencl-nvidia
 ```
 For older GPUs, use drivers from the AUR:
-```
-Kepler series newest driver: 470xx
+```bash frame="none"
+# Kepler series newest driver: 470xx
 yay -S nvidia-470xx-dkms nvidia-470xx-utils opencl-nvidia-470xx
 
-Fermi series newest driver: 390xx
+# Fermi series newest driver: 390xx
 yay -S nvidia-390xx-dkms nvidia-390xx-utils opencl-nvidia-390xx
 ```
 

--- a/docs/src/content/docs/guides/remote-services.md
+++ b/docs/src/content/docs/guides/remote-services.md
@@ -6,7 +6,7 @@ description: How to setup and use remote mmx services.
 The following steps are provided for running multiple harvesters with a single node, or for separate node / farmer / wallet setups.
 
 To enable remote access to a Node or Farmer:
-```
+```bash frame="none"
 echo true > config/local/allow_remote
 ```
 Alternatively, see "Allow remote service access" in GUI Settings.
@@ -16,7 +16,7 @@ Remote harvesters need access to port `11333`, while remote farmer, timelord and
 ### Remote Harvester
 
 To run a remote harvester:
-```bash title="Remote Harvester"
+```bash frame="none"
 ./run_harvester.sh -n node.ip
 ```
 Alternatively to set the node address permanently: `echo node.ip > config/local/node`
@@ -28,7 +28,7 @@ To disable the built-in harvester in the node: `echo false > config/local/harves
 ### Remote Farmer
 
 To run a remote farmer with it's own wallet and harvester:
-```bash title="Remote Farmer"
+```bash frame="none"
 ./run_farmer.sh -n node.ip
 ```
 Alternatively to set the node address permanently: `echo node.ip > config/local/node`
@@ -40,7 +40,7 @@ To disable the built-in harvester in the farmer: `echo false > config/local/harv
 ### Remote Timelord
 
 To run a remote timelord:
-```bash title="Remote Timelord"
+```bash frame="none"
 ./run_timelord.sh -n node.ip
 ```
 Alternatively to set the node address permanently: `echo node.ip > config/local/node`
@@ -50,7 +50,7 @@ To disable the built-in timelord in the node: `echo false > config/local/timelor
 ### Remote Wallet
 
 To run a remote wallet:
-```bash title="Remote Wallet"
+```bash frame="none"
 ./run_wallet.sh -n node.ip
 ```
 Alternatively to set the node address permanently: `echo node.ip > config/local/node`
@@ -62,7 +62,7 @@ To disable the built-in wallet in the node: `echo false > config/local/wallet`
 To use the remote services over a public network such the internet you should use an SSH tunnel, instead of opening port `11330` or `11333` to the world (which would hurt security).
 
 To run an SSH tunnel to connect to a node from another machine (such as from a remote farmer):
-```bash title="SSH Tunnel"
+```bash frame="none"
 ssh -N -L 11330:localhost:11330 user@node.ip
 ```
 This will forward local port `11330` to port `11330` on the node's machine.

--- a/docs/src/content/docs/software/MMX_script.md
+++ b/docs/src/content/docs/software/MMX_script.md
@@ -233,9 +233,9 @@ Account balances can be up to 128-bit, while amounts (for deposit and sending) a
 Let's say we choose 64-bit precision.
 This means we multiply all constants by 2^64 (or left shift by 64) and right shift by 64 to get a result.
 For example `123456 * 1.337 = 165060.672`:
-```
-const factor = 24663296826549670511; 		// 1.337
-const result = (123456 * factor) >> 64;		// 165060
+```js
+const factor = 24663296826549670511;       // 1.337
+const result = (123456 * factor) >> 64;    // 165060
 ```
 Fixed point arithmetic always rounds down.
 When converting floating point constants, rounding to nearest is best for accuracy.
@@ -287,7 +287,7 @@ null + 1
 ### Contract Storage
 
 Any global variable will be persisted accross the lifetime of a contract:
-```
+```js
 var storage = [];
 function add(value) public {
 	push(storage, value);
@@ -301,7 +301,7 @@ function get() const public {
 
 Any `static` private function can be a constructor. When deploying a contract you have to specify which function to use. \
 The default is to use `init()`:
-```
+```js
 var foo;
 var spec;
 function init(bar) {
@@ -318,7 +318,7 @@ Note: Global variables are initialized to `null` before constructor is executed.
 ### Deposit
 
 Deposits in MMX are made through function calls to a `payable` function:
-```
+```js
 var currency = bech32();
 var balances = {};
 function deposit(account) public payable {
@@ -389,7 +389,7 @@ A smart contract's code is actually a separate "contract" of type `mmx.contract.
 Multiple contracts can share the same binary, this reduces the cost of deploying contracts significantly.
 
 If the code is not deployed on-chain yet, it needs to be compiled and deployed first:
-```
+```bash frame="none"
 mmx_compile -t -n testnet12 -f example.js -o example.dat
 mmx wallet deploy example.dat
 ```
@@ -398,7 +398,7 @@ mmx wallet deploy example.dat
 
 Once the binary is confirmed on-chain, we can deploy any number of contracts with the same code. \
 This can be done via JSON files:
-```
+```json
 {
 	"__type": "mmx.contract.Executable",
 	"name": "Example",
@@ -413,47 +413,47 @@ If the contract does not represent a token, `name`, `symbol` and `decimals` can 
 If `init_method` is "init", it can be omitted as well since it's the default.
 
 Now deploying a contract from JSON file:
-```
+```bash frame="none"
 mmx wallet deploy example.json
 ```
 Every contract will have a different address since the wallet generates a random 64-bit transaction nonce by default.
 
 The node keeps track which `sender` deployed a contract, as such you can view all your deployed contracts via:
-```
+```bash frame="none"
 mmx wallet show contracts
 ```
 
 ### Executing a smart contract function
 
 Executing a smart contract function can be done via command line:
-```
+```bash frame="none"
 mmx wallet exec <method> [args] -x <contract>
 ```
 This will submit a transaction to the network.
 
 To make a deposit:
-```
+```bash frame="none"
 mmx wallet deposit <method> [args] -a <amount> -x <currency> -t <contract>
 ```
 Be careful not to confuse `-x` and `-t`: `-t` is the destination, while `-x` is the currency to deposit.
 
 By default `this.user` is set to the wallet's first address (index `0`).
 This can be overriden with a different address index:
-```
+```bash frame="none"
 mmx wallet exec <method> [args] -k <index>
 mmx wallet exec <method> [args] -k -1  # this will set `user` to `null`
 ```
 The same applies to `mmx wallet deposit`.
 
 Specific examples:
-```
+```bash frame="none"
 mmx wallet exec test_me 1 2 3 -x mmx1...
 mmx wallet deposit test_me 1 2 3 -x mmx1... -t mmx1...  # `-t` is like `-x` for `exec`
 mmx wallet deposit -x mmx1... -t mmx1...  # this will call `deposit()` without args
 ```
 
 To execute a function just for testing:
-```
+```bash frame="none"
 mmx node call <method> [args] -x <contract>
 ```
 This will not submit any transaction, but rather just simulate a call at the current blockchain `height + 1`.
@@ -461,24 +461,24 @@ This will not submit any transaction, but rather just simulate a call at the cur
 ### Inspecting a Contract
 
 To view the contract that was deployed:
-```
+```bash frame="none"
 mmx node get contract <address>
 ```
 
 To view a contract's state (global storage variables):
-```
+```bash frame="none"
 mmx node read -x <address>
 mmx node read <field> -x <address>  # `field` can be a variable name or hex address `0x...`
 ```
 
 To dump a contracts's entire storage:
-```
+```bash frame="none"
 mmx node dump -x <address>
 ```
 `<0x...>` denotes a reference, `[0x...,size]` denotes an array, `{0x...}` denotes a map / object.
 
 To dump a contract's binary code:
-```
+```bash frame="none"
 mmx node dump_code -x <address>
 ```
 
@@ -498,13 +498,13 @@ Memory is unified in MMX, but there are regions for different usage:
 As in JavaScript: Arrays, Maps and Objects are reference counted.
 
 That means "copying" by assignment does not make a deep copy, it only copies the reference:
-```
+```js
 const array = [1, 2, 3];
 const tmp = array;
 push(tmp, 4);
 return array;	// returns [1, 2, 3, 4]
 ```
-```
+```js
 const object = {"foo": {}};
 const foo = object.foo;
 foo.bar = true;
@@ -515,7 +515,7 @@ In order to make a deep-copy you need to use `clone()`.
 ### clone() from storage
 
 It's not possible to clone maps / objects from contract storage:
-``` 
+```js
 var object = {};
 function test() public {
 	return clone(object);		// will fail
@@ -537,11 +537,3 @@ Note: `this.balance` is updated automatically when receiving funds via deposit, 
 ### Instruction costs
 
 TODO
-
-
-
-
-
-
-
-

--- a/docs/src/content/docs/software/RPC_protocol.md
+++ b/docs/src/content/docs/software/RPC_protocol.md
@@ -14,7 +14,7 @@ A web-friendly `/wapi/` is available for select features.
 Authentication is required to access private API endpoints or remove limits from public enpoints.
 
 The best way to setup static authentication is to create an API token, by editing `config/local/HttpServer.json`:
-```
+```json
 {
 	"token_map": [
 		["secure_random_token_here", "ADMIN"]
@@ -396,7 +396,7 @@ Request payload is an object of arguments:
 Returns contract address (bech32) if successful.
 
 Example `payload` for a smart contract:
-```
+```json
 {
 	"__type": "mmx.contract.Executable",
 	"name": "Fake Testnet USD",

--- a/docs/src/content/docs/software/cli-commands.md
+++ b/docs/src/content/docs/software/cli-commands.md
@@ -3,7 +3,7 @@ title: CLI Commands
 description: MMX Node CLI Command Reference.
 ---
 When compiled from source:
-```
+```bash frame="none"
 cd mmx-node
 source ./activate.sh
 ```
@@ -171,7 +171,10 @@ To reload plots: `mmx harvester reload`
 To use pooling first create a plot NFT, then create plots for it and finally join a pool.
 
 ### Create Plot NFT
-`mmx wallet plotnft create <name>`
+
+```bash frame="none"
+mmx wallet plotnft create <name>
+```
 
 `<name>` can be any string without whitespace.
 
@@ -182,15 +185,20 @@ Note: Need to wait for the transaction to confirm before it will show up.\
 Note: This command takes the usual `-j <index>` argument to select a different wallet.
 
 ### Show Plot NFTs
-`mmx wallet plotnft show`
+
+```bash frame="none"
+mmx wallet plotnft show
+```
 
 The address shown in `[...]` is the plot NFT contract address, which needs to be used for plotting.
 
 Note: This command takes the usual `-j <index>` argument to select a different wallet.
 
 Example:
+```bash frame="none"
+mmx wallet plotnft show -j 1
 ```
-$ mmx wallet plotnft show -j 1
+```
 [mmx1wknv8xxvzjafrswsrwr3l85y6d8nms2dz22dgxl2qpcyjp64amtsjqjna5]
   Name: test1
   Locked: true
@@ -200,23 +208,34 @@ $ mmx wallet plotnft show -j 1
 ### Join a Pool
 First you need to obtain the pool server URL for the pool, via their website or discord.
 
-`mmx wallet plotnft join <pool_url> -x <plot_nft_address>`
+```bash frame="none"
+mmx wallet plotnft join <pool_url> -x <plot_nft_address>
+```
 
 `<plot_nft_address>` is the same as used for plotting, see `mmx wallet plotnft show`.
 
 Note: This command does not need any `-j` to select a wallet.
 
-Example: `mmx wallet plotnft join http://localhost:8080 -x mmx1wknv8xxvzjafrswsrwr3l85y6d8nms2dz22dgxl2qpcyjp64amtsjqjna5`
+Example:
+```bash frame="none"
+mmx wallet plotnft join http://localhost:8080 -x mmx1wknv8xxvzjafrswsrwr3l85y6d8nms2dz22dgxl2qpcyjp64amtsjqjna5
+```
 
 ### Leave Pool
-`mmx wallet plotnft unlock -x <plot_nft_address>`
+
+```bash frame="none"
+mmx wallet plotnft unlock -x <plot_nft_address>
+```
 
 This will take 256 blocks to complete, to avoid cheating.
 Once complete the plot NFT is in solo farming mode, which means block rewards will directly go to your Farmer reward address.
 
 Note: This command does not need any `-j` to select a wallet.
 
-Example: `mmx wallet plotnft unlock -x mmx1wknv8xxvzjafrswsrwr3l85y6d8nms2dz22dgxl2qpcyjp64amtsjqjna5`
+Example:
+```bash frame="none"
+mmx wallet plotnft unlock -x mmx1wknv8xxvzjafrswsrwr3l85y6d8nms2dz22dgxl2qpcyjp64amtsjqjna5
+```
 
 ### Switch Pool
 First leave the current pool, wait 256 blocks for the plot NFT to unlock, then join the new pool as shown above.
@@ -227,8 +246,10 @@ To see pool account: `mmx pool info`
 To see partials info: `mmx farm info`
 
 Example:
+```bash frame="none"
+mmx pool info
 ```
-$ mmx pool info
+```
 Pool [http://localhost:8080]
   Balance: 1.5 MMX
   Total Paid: 123.456 MMX
@@ -239,9 +260,10 @@ Pool [http://localhost:8080]
   Estimated Space: 13.3789 TB
 ```
 
+```bash frame="none"
+mmx farm info
 ```
-$ mmx farm info
-...
+```
 Plot NFT [mmx1wknv8xxvzjafrswsrwr3l85y6d8nms2dz22dgxl2qpcyjp64amtsjqjna5]
   Name: test1
   Server URL: http://localhost:8080


### PR DESCRIPTION
PR with added syntax highlight attrib on code sections (docs)

Changes:
- Added ` ```bash frame="none" ` to existing code sections identified as system shell
  - Using `frame="none"` to not get extra markdown terminal `ooo` header (just takes space)
- Added ` ```json ` to existing code sections identified as JSON
- Added ` ```js ` to existing code sections identified as JavaScript
- No change of actual code text logic, but tuned some (visually)
  - Changed/added `#` in code where logical (comments)
  - Removed a few `$` in code (not needed, implicit)
  - Rearranged/split a few code sections (visually)
  - Removed a few `title=""` (not needed, normal text header right above)
  - Changed a few ` `` ` code text to code sections  (visually better)