### PR TITLE
win gha: pin cmake version

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -46,6 +46,8 @@ jobs:
           nvcc -V
           
       - uses: lukka/get-cmake@latest
+        with:
+          cmakeVersion: "~3"
 
       - name: Restore artifacts, or setup vcpkg (do not install any package)
         uses: lukka/run-vcpkg@v11


### PR DESCRIPTION
The Windows GHA build is broken due to the CMake 4.0.0 release. Fixed by pinning CMake to the latest 3.x.x version