### PR TITLE
Align/clean, Docs

### DIFF
--- a/docs/src/content/docs/articles/general/mmx-tldr.md
+++ b/docs/src/content/docs/articles/general/mmx-tldr.md
@@ -16,7 +16,7 @@ What is the [MMX blockchain](https://mmx.network/) ?
 
 _&#8220;&nbsp;MMX &ndash; fast, low cost, feature rich, decentralized &ndash; with tokenomics of an actual currency&nbsp;&#8221;_
 
-:::note
+:::note[Note]
 In-depth technical, read [whitepaper](../../../articles/general/mmx-whitepaper/). Technical breakdown, read [reference](../../../reference/blockchain/).
 :::
 
@@ -108,7 +108,9 @@ Ethereum is usually listed with anything from 15-50 maximum TPS. Real-life stati
 - **Chia**: `Documented as 20-40 TPS, real-life stress tests at 35` = `~35`\
 Not easy to get hard numbers to calculate Chia's maximum TPS potential. It is documented to be in the 20-40 range. A real-life stress test, with simplest-TX-es, have given about 35 TPS.
 
-_NOTE: An 100% apples to apples comparison is not possible without overly complicating it. Each blockchain has unique properties, real-life behavior, and limitations. This is an attempt to estimate a realistic capacity potential. As fair as possible, in a simple table._
+:::note[Note]
+An 100% apples to apples comparison is not possible without overly complicating it. Each blockchain has unique properties, real-life behavior, and limitations. This is an attempt to estimate a realistic capacity potential. As fair as possible, in a simple table.
+:::
 
 </details>
 

--- a/docs/src/content/docs/articles/general/mmx-whitepaper.mdx
+++ b/docs/src/content/docs/articles/general/mmx-whitepaper.mdx
@@ -17,10 +17,10 @@ import { LinkButton } from '@astrojs/starlight/components';
 Whitepaper for the MMX Blockchain & Currency.
 
 <LinkButton href="/MMX_Whitepaper_290125.pdf" icon="download" iconPlacement="start">
-	Download PDF
+  Download PDF
 </LinkButton>
 
-:::note
+:::note[Note]
 Technical breakdown, read [reference](../../../reference/blockchain/). Light introduction, read [article](../../../articles/general/mmx-tldr/).
 :::
 

--- a/docs/src/content/docs/articles/plotting/plot-format.md
+++ b/docs/src/content/docs/articles/plotting/plot-format.md
@@ -14,7 +14,9 @@ authorURL: https://github.com/voidxno
 
 Plot format, MMX.
 
-_**IMPORTANT:**_ _My own understanding, reading comments when mainnet plot format was rolled out with testnet11. Still relevant info, as an introduction. Reference official information if unsure._
+:::note[Important]
+My own understanding, reading comments when mainnet plot format was rolled out with testnet11. Still relevant info, as an introduction. Reference official information if unsure.
+:::
 
 ## TLDR;
 
@@ -69,8 +71,10 @@ Given the high IOPS for SSD-plots, recommended to use C0 for compression (0%).
 | `hdd`/`sdd-k31` | 216 GB | 120 GB | 8 GB |
 | `hdd`/`sdd-k32` | 410 GB | 232 GB | 8 GB |
 
-_NOTE: Disk mode usually less than 8 GB, depends on `-S` streams option._\
-_NOTE: If close to 32 GB, 32 GB system RAM not enough. 48/64 GB needed._
+:::note[Note]
+Disk mode usually less than 8 GB, depends on `-S` streams option.\
+If close to 32 GB, 32 GB system RAM not enough. 48/64 GB needed.
+:::
 
 **Temp disk space** needed when plotting (similar for HDD and SSD-plots):
 | | full RAM | partial RAM | disk mode |
@@ -88,7 +92,9 @@ _NOTE: If close to 32 GB, 32 GB system RAM not enough. 48/64 GB needed._
 | `hdd`/`sdd-k31` | 0.16 / 0.06 TiBW | 0.33 / 0.25 TiBW | 1.40 / 1.14 TiBW |
 | `hdd`/`sdd-k32` | 0.32 / 0.13 TiBW | 0.67 / 0.50 TiBW | 2.88 / 2.27 TiBW |
 
-- Testnet11 introduced a new farmer key, 33 bytes ECDSA vs old 48 BLS (`-f`, 66 chars vs old 96).
+:::note[Note]
+Testnet11 introduced a new farmer key, 33 bytes ECDSA vs old 48 BLS (`-f`, 66 chars vs old 96).
+:::
 
 Follow [`#mmx-general`](https://discord.com/channels/852982773963161650/925017012235817042) on Discord.
 

--- a/docs/src/content/docs/articles/timelord/timelord-optimizations.md
+++ b/docs/src/content/docs/articles/timelord/timelord-optimizations.md
@@ -14,13 +14,15 @@ authorURL: https://github.com/voidxno
 
 Running an MMX TimeLord is optional (default is disabled). Not needed to run a fully functional node.
 
-Blockchain, as a whole, only need one active timelord to move forward. A few more, spread around, is preferred for redundancy and security.
+Blockchain, as a whole, only need one active timelord to move forward. A few more, spread around, is preferred for redundancy and security. Do not need to be fastest.
 
 If you want to contribute by running one, check [requirements](#requirements) below. Enable timelord in WebGUI, or set `true` in `config/local/timelord` file. Check that running, and speed, in NODE / LOG / TIMELORD tab in WebGUI. Probably lower than NODE / VDF Speed, unless you are the fastest timelord.
 
 No more is needed. Standard Linux compile and Windows binaries gives good performance for a timelord. Unless you want to optimize for fastest timelord, or the fun of it.
 
-_**IMPORTANT:**_ _Trying to be fastest TimeLord is not easy. YOU need to decide if worth it. **Overclock at your own risk, CPU can degrade**. Information shared here, is to **best of my knowledge as of Mar2025**._
+:::caution[Important]
+Trying to be fastest TimeLord is not easy. _YOU_ need to decide if worth it. **Overclock at your own risk, CPU can degrade**. Information shared here, is to **best of my knowledge as of Mar2025**.
+:::
 
 ## TLDR;
 
@@ -33,7 +35,9 @@ I want to run [fastest timelord](../../../articles/timelord/timelord-predictions
 * Have a GPU/iGPU verify VDF
 * [Clock 1x CPU core](#optimize-cpu-speed) as high as possible
 
-_NOTE: Optimize and **overclock at your own risk**._
+:::note[Note]
+Optimize and **overclock at your own risk**.
+:::
 
 ## Logic
 
@@ -74,7 +78,9 @@ You do not need to complicate it like below. Try to run a timelord. Measure spee
 
 Discuss and share in [`#mmx-timelord`](https://discord.com/channels/852982773963161650/1026219599311675493) channel on Discord. No requirement to divulge all your secrets. But a good place to get tips, or kickstart new ideas.
 
-_NOTE: Optimize and overclock at your own risk._
+:::note[Note]
+Optimize and **overclock at your own risk**.
+:::
 
 ### Test Environment
 
@@ -158,9 +164,11 @@ export LD=/usr/bin/ld.lld-19
 ./make_devel.sh
 ```
 
-_NOTE: You need to perform `export` statements in terminal environment before compile, or gcc14 will be used._<br>
-_NOTE: When you switch compiler, or compiler options. Always do `./clean_all.sh` before new compile._<br>
-_NOTE: You will get a lot of unused `-fmax-errors=1` warnings. Just ignore, or remove from compiler options._
+:::note[Note]
+You need to perform `export` statements in terminal environment before compile, or gcc14 will be used.\
+When you switch compiler, or compiler options. Always do `./clean_all.sh` before new compile.\
+You will get a lot of unused `-fmax-errors=1` warnings. Just ignore, or remove from compiler options.
+:::
 
 Default Clang19 compile (`./make_devel.sh`):
 
@@ -184,7 +192,9 @@ Some elements to experiment with (`./make_devel.sh`):
 
 There are others. Look up optimization in relevant compiler documentation.
 
-_NOTE: When you switch compiler, or compiler options. Always do `./clean_all.sh` before new compile._<br>
+:::note[Note]
+When you switch compiler, or compiler options. Always do `./clean_all.sh` before new compile.
+:::
 
 ### Optimize: Compiler options (AVX vs SSE4.2)
 
@@ -212,7 +222,9 @@ Small, but real jump from gcc14's **1.308** MH/s/0.1GHz:
 | :--- | :--- | :--- | :--- |
 | Ubuntu/gcc14 | 43.58 MH/s | /33 (3.3 GHz) | **1.320** MH/s/0.1GHz |
 
-_NOTE: For now, official releases will keep having SSE4.2 as baseline._
+:::note[Note]
+For now, official releases will keep having SSE4.2 as baseline.
+:::
 
 ### Optimize: Source code
 
@@ -269,7 +281,9 @@ Syntax becomes `isolcpus=8,9,10,11` and `taskset -cp 8-11 5122`. How OS process 
 
 At this stage we know what to expect for each 0.1 GHz, **1.351** MH/s. All testing we have observed have given linear increase, given CPU GHz. Now it is time to clock CPU core as high as possible.
 
-_NOTE: Optimize and **overclock at your own risk**._
+:::note[Note]
+Optimize and **overclock at your own risk**.
+:::
 
 First a boring observation. Many elements surrounding raw GHz of CPU core have been tested:
 

--- a/docs/src/content/docs/articles/timelord/timelord-predictions.md
+++ b/docs/src/content/docs/articles/timelord/timelord-predictions.md
@@ -39,7 +39,9 @@ Leaves us with newest Intel/AMD CPUs that can clock 1x core the highest:
 - Intel Ultra 200S series (15th-gen, Arrow Lake)
 - AMD Ryzen 7000/9000 series (Zen 4/5)
 
-_NOTE: [eBACS](https://bench.cr.yp.to) have [SHA256 efficiency benchmarks](https://bench.cr.yp.to/impl-hashblocks/sha256.html) for different CPU architectures with SHA extensions (dolbeau/amd64-sha)._
+:::note[Note]
+[eBACS](https://bench.cr.yp.to) have [SHA256 efficiency benchmarks](https://bench.cr.yp.to/impl-hashblocks/sha256.html) for different CPU architectures with SHA extensions (dolbeau/amd64-sha).
+:::
 
 ## Today (Mar2025)
 

--- a/docs/src/content/docs/articles/wallets/wallets-mnemonic-passphrase.md
+++ b/docs/src/content/docs/articles/wallets/wallets-mnemonic-passphrase.md
@@ -14,7 +14,9 @@ authorURL: https://github.com/voidxno
 
 A look at MMX wallets, mnemonic and passphrase.
 
-_**IMPORTANT:**_ _My own understanding, using mmx-node. I take no responsibility for content. When it comes to crypto and wallets, YOU need to educate yourself. As always, NEVER share your mnemonic or passphrase with others._
+:::note[Important]
+My own understanding, using mmx-node. I take no responsibility for content. When it comes to crypto and wallets, _YOU_ need to educate yourself. As always, _NEVER_ share your mnemonic or passphrase with others.
+:::
 
 ## TLDR;
 
@@ -37,7 +39,6 @@ As long as you **backup** (securely), in some way, the **24-words mnemonic** and
 
 Also recommended to **note** the **finger\_print** and main **address** of wallet (Index[0]). Easy indicators to make sure you recreated the correct wallet with backup information.
 
-
 :::caution[Important]
 Perform the two steps above, and you will always be able to recreate and verify wallet.
 :::
@@ -48,13 +49,15 @@ Look [Find elements](#find-elements) on how to find information above.
 
 You can also backup (securely), the `.dat` file, that represents the wallet. Not really needed. The 24-words mnemonic and passphrase (if used), are enough to recreate wallet. Also, if wallet was created with a passphrase. You still need passphrase to access wallet, in addition to `.dat` file.
 
-:::tip
+:::tip[Tip]
 Topics in this article can be tricky to get a grip on. Try asking an LLM chatbot about _"BIP39 wallet standard"_, _"mnemonic"_ and _"passphrase"_. Converse, and you might get answers with angles that works better for you.
 :::
 
 ## Mnemonic
 
-_NOTE: Ignoring optional passphrase for now (25th word), that is next section._
+:::note[Note]
+Ignoring optional passphrase for now (25th word), that is next section.
+:::
 
 The 24-words mnemonic is a user friendly way to represent the raw binary hexadecimals seed value for wallet ([BIP39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki)).
 
@@ -162,7 +165,9 @@ So, if missing funds on a wallet. Make sure it is not issue above, by recreating
 
 ## Account Index
 
-_NOTE: Only an explanation that accounts within a wallet technically exists. Not needed in normal usage._
+:::note[Note]
+Only an explanation that accounts within a wallet technically exists. Not needed in normal usage.
+:::
 
 The 'Account' word can mislead in this context. Each wallet listed in WebGUI are also 'Accounts'. What we are talking about here is 'Account Index' **within a wallet**.
 

--- a/docs/src/content/docs/faq/general.md
+++ b/docs/src/content/docs/faq/general.md
@@ -59,6 +59,7 @@ There is a project funding fee.
 It is a 1% fee on *transaction fees*, <ins>not block reward</ins>. To fund continued development of MMX. More nuances to how it works, read Project Funding section of [whitepaper](../../../articles/general/mmx-whitepaper/).
 
 ### Where can I find MMX branding assets?
+
 Go to [mmx-assets](https://github.com/madMAx43v3r/mmx-assets) repository. Basic info, logo and assets folders:
 - [`/logo/artwork/`](https://github.com/madMAx43v3r/mmx-assets/tree/master/logo/artwork/) _(artwork)_
 - [`/logo/assets/`](https://github.com/madMAx43v3r/mmx-assets/tree/master/logo/assets/) _(misc)_

--- a/docs/src/content/docs/guides/docker.md
+++ b/docs/src/content/docs/guides/docker.md
@@ -89,11 +89,14 @@ services:
       MMX_HARVESTER_ENABLED: 'true'  # Set to false to disable local harvester
       MMX_FARMER_ENABLED: 'true'  # Set to false to disable local farmer
 ```
-Note: Intel ARC support requires a host system running Linux Kernel 6.3 or above
+
+:::note[Note]
+Intel ARC support requires a host system running Linux Kernel 6.3 or above.
+:::
 
 ### NVIDIA GPU
 
-For nvidia gpu support please see the following `compose.yml`:
+For Nvidia gpu support please see the following `compose.yml`:
 ```yml
 services:
   node:
@@ -112,11 +115,14 @@ services:
       MMX_HARVESTER_ENABLED: 'true'  # Set to false to disable local harvester
       MMX_FARMER_ENABLED: 'true'  # Set to false to disable local farmer
 ```
-Note: for nvidia you also need the `NVIDIA Container Toolkit` installed on the host, for more info please see: https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html
+
+:::note[Note]
+For Nvidia you also need the `NVIDIA Container Toolkit` installed on the host, for more info please see: [Installing the NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html).
+:::
 
 ## Remote Services
 
- - Running a remote harvester or farmer can be done by overwriting the `CMD` of the Dockerfile, for example like this:
+Running a remote harvester or farmer can be done by overwriting the `CMD` of the Dockerfile, for example like this:
 
 ### Remote Harvester
 

--- a/docs/src/content/docs/guides/getting-started.md
+++ b/docs/src/content/docs/guides/getting-started.md
@@ -1,11 +1,12 @@
 ---
 title: Getting Started
 description: Getting started with MMX.
-i18nReady: true
 ---
+
 **[Install](../installation/) MMX-Node.**
 
 ## GUI
+
 The native GUI can be opened by searching for `MMX Node` (when installed via binary package).
 
 In case of compiling from source:
@@ -15,6 +16,7 @@ In case of compiling from source:
 ```
 
 ### WebGUI
+
 The WebGUI is available at: http://localhost:11380/gui/
 
 See `$MMX_HOME/PASSWD` or `mmx-node/PASSWD` for the login password, it is auto generated at compile time.
@@ -30,7 +32,9 @@ source ./activate.sh
 ```
 With a binary package install, just open a new terminal. On Windows search for `MMX CMD`.
 
-Note: A new wallet can also be created in the GUI.
+:::note[Note]
+A new wallet can also be created in the GUI.
+:::
 
 ### Creating a Wallet (offline)
 
@@ -59,7 +63,9 @@ To get the mnemonic seed from a wallet (with Node / Wallet already running):
 mmx wallet get seed [-j index]
 ```
 
-Note: A Node / Wallet restart is needed to pick up a new wallet.
+:::note[Note]
+A Node / Wallet restart is needed to pick up a new wallet.
+:::
 
 ### Creating a Wallet (online)
 
@@ -83,15 +89,18 @@ First perform the installation and setup steps, then:
 You can enable port forwarding on TCP port 11337, if you want to help out the network and accept incoming connections.
 
 ### Configuration
-Note: Capitalization of configuration files names matters. \
-Note: Any config changes require a node restart to become effective.
+
+:::note[Note]
+Capitalization of configuration files names matters.\
+Any config changes require a node restart to become effective.
+:::
 
 #### Custom Farmer Reward Address
 
 Create / Edit file `config/local/Farmer.json`:
 ```json
 {
-	"reward_addr": "mmx1..."
+  "reward_addr": "mmx1..."
 }
 ```
 By default the first address of the first wallet is used.
@@ -101,7 +110,7 @@ By default the first address of the first wallet is used.
 Create / Edit file `config/local/TimeLord.json`:
 ```json
 {
-	"reward_addr": "mmx1..."
+  "reward_addr": "mmx1..."
 }
 ```
 
@@ -110,11 +119,12 @@ Create / Edit file `config/local/TimeLord.json`:
 Create / Edit file `config/local/Router.json`:
 ```json
 {
-	"fixed_peers": ["192.168.0.123", "more"]
+  "fixed_peers": ["192.168.0.123", "more"]
 }
 ```
 
 #### Enable Timelord
+
 ```bash frame="none"
 echo true > config/local/timelord
 ```
@@ -124,8 +134,8 @@ echo true > config/local/timelord
 Create / Edit `config/local/cuda.json`:
 ```json
 {
-	"enable": true,
-	"devices": [0, 1, ...]
+  "enable": true,
+  "devices": [0, 1, ...]
 }
 ```
 Empty device list = use all devices. Device indices start at 0. CUDA is enabled by default for all devices.
@@ -140,7 +150,9 @@ Wallet files will end up in `MMX_HOME`, everything else in `mainnet` subfolder.
 When compiling from source, `MMX_HOME` is not set, so it defaults to the current directory.
 When installing a binary package `MMX_HOME` defaults to `~/.mmx/`.
 
-Note: A trailing `/` in the path is required.
+:::note[Note]
+A trailing `/` in the path is required.
+:::
 
 #### Custom data directory
 
@@ -150,7 +162,9 @@ export MMX_DATA=/mnt/mmx_data/
 ```
 A node restart is required. Optionally the `mainnet` folder can be copied to the new `MMX_DATA` path (after stopping the node), to avoid having to sync from scratch again.
 
-Note: A trailing `/` in the path is required.
+:::note[Note]
+A trailing `/` in the path is required.
+:::
 
 #### Reducing network traffic
 
@@ -158,8 +172,8 @@ If you have a slow internet connection or want to reduce traffic in general you 
 For example to run at the bare recommended minimum:
 ```json
 {
-	"num_peers_out": 4,
-	"max_connections": 4
+  "num_peers_out": 4,
+  "max_connections": 4
 }
 ```
 `num_peers_out` is the maximum number of outgoing connections to synced peers. `max_connections` is the maximum total number of connections.
@@ -182,7 +196,6 @@ screen -r node    # to attach again
 To re-sync starting from a specific height: `mmx node revert <height>`.
 This is needed if for some reason the node forked from the network. Just subtract 1000 blocks or more from the current height you are stuck at.
 
-
 ## Plotting
 
 **For an in depth guide on plotting, see** [Plotting Guide](../mmx-plotter/).
@@ -193,13 +206,15 @@ mmx wallet keys [-j index]
 ```
 The node needs to be running for this command to work. (`-j` to specify the index of a non-default wallet)
 
-Via GUI the farmer key can be found in Wallet > Info section, see `farmer_public_key`: 
+Via GUI the farmer key can be found in Wallet > Info section, see `farmer_public_key`:
 
 ![image](https://github.com/madMAx43v3r/mmx-node/assets/951738/7ebc8eaa-d0f9-43fd-bb87-0788a59b138a)
 
-Note: During plotting, the node does not need to be running (the plotter doesn't even need internet connection).
+:::note[Note]
+During plotting, the node does not need to be running (the plotter doesn't even need internet connection).
+:::
 
-Download CUDA plotter here: https://github.com/madMAx43v3r/mmx-binaries/tree/master/mmx-cuda-plotter
+Download CUDA plotter here: [mmx-binaries/mmx-cuda-plotter](https://github.com/madMAx43v3r/mmx-binaries/tree/master/mmx-cuda-plotter)
 
 There is no CPU plotter anymore for the new format, because it would be too inefficient. Any old Nvidia GPU will do, Maxwell or newer.
 
@@ -221,11 +236,11 @@ The minimum k-size for mainnet is k29, the maximum k-size is k32.
 To add a plot directory add the path to `plot_dirs` array in `config/local/Harvester.json`, for example:
 ```json
 {
-	"plot_dirs": [
-		"/mnt/drive1/plots/",
-		"/mnt/drive2/plots/",
-		"C:/windows/path/example/"
-	]
+  "plot_dirs": [
+    "/mnt/drive1/plots/",
+    "/mnt/drive2/plots/",
+    "C:/windows/path/example/"
+  ]
 }
 ```
 Directories are searched recursively by default. To disable recursive search you can set `recursive_search` to `false` in `Harvester.json`.

--- a/docs/src/content/docs/guides/installation.md
+++ b/docs/src/content/docs/guides/installation.md
@@ -5,14 +5,15 @@ description: How to install MMX Node.
 
 ## Windows
 
-Windows installers are available here: https://github.com/madMAx43v3r/mmx-node/releases
+Windows installers are available here: [mmx-node/releases](https://github.com/madMAx43v3r/mmx-node/releases)
 
-You might need to install or update "Microsoft Visual C++ Redistributable for Visual Studio 2022" to the latest:\
-Scroll down to "Other Tools" here: https://visualstudio.microsoft.com/downloads/
+:::note[Note]
+You might need to install or update [Microsoft Visual C++ Redistributable for Visual Studio 2022](https://visualstudio.microsoft.com/downloads/). Scroll down to "Other Tools".
+:::
 
 ## Linux
 
-Linux binary packages are available here: https://github.com/madMAx43v3r/mmx-node/releases
+Linux binary packages are available here: [mmx-node/releases](https://github.com/madMAx43v3r/mmx-node/releases)
 
 To install a binary package:
 ```bash frame="none"
@@ -49,7 +50,9 @@ sudo yum install kernel-devel git cmake automake libtool curl gcc gcc-c++ miniup
 sudo yum install qt5-qtwebengine-devel  # for native GUI
 ```
 
-Note: To enable CUDA support, CUDA needs to be installed: https://developer.nvidia.com/cuda-downloads
+:::note[Note]
+To enable CUDA support, CUDA needs to be installed: [CUDA Toolkit Downloads](https://developer.nvidia.com/cuda-downloads).
+:::
 
 ### Building from Source
 
@@ -59,8 +62,8 @@ cd mmx-node
 ./update.sh
 ```
 
-To disable QT GUI: `./update.sh -D DISABLE_QT=1` \
-To disable CUDA support: `./update.sh -D DISABLE_CUDA=1` \
+To disable QT GUI: `./update.sh -D DISABLE_QT=1`\
+To disable CUDA support: `./update.sh -D DISABLE_CUDA=1`\
 These settings are stored, until the next `./clean_all.sh`, so only needs to be specified once. To enable again, set the config to `0`.
 
 To update to latest version:
@@ -79,16 +82,15 @@ This is needed when updating system packages for example.
 
 ## Windows via WSL
 
-To setup Ubuntu 20.04 in WSL on Windows you can follow the tutorial over here: \
-https://docs.microsoft.com/en-us/learn/modules/get-started-with-windows-subsystem-for-linux/
+To setup Ubuntu 20.04 in WSL on Windows you can follow the tutorial over here:\
+[Get started with Windows Subsystem for Linux](https://docs.microsoft.com/en-us/learn/modules/get-started-with-windows-subsystem-for-linux/)
 
-Make sure to install Ubuntu in step 2: https://www.microsoft.com/store/p/ubuntu/9nblggh4msv6
+In steps, make sure to install: [Ubuntu on Windows](https://www.microsoft.com/store/p/ubuntu/9nblggh4msv6)
 
 Then type "Ubuntu" in the start menu and start it, you will be asked to setup a user and password.
 After that you can follow the normal instructions for Ubuntu 20.04.
 
-To get OpenCL working in WSL:
-https://devblogs.microsoft.com/commandline/oneapi-l0-openvino-and-opencl-coming-to-the-windows-subsystem-for-linux-for-intel-gpus/
+To get OpenCL working in WSL: [OpenCL coming to WSL](https://devblogs.microsoft.com/commandline/oneapi-l0-openvino-and-opencl-coming-to-the-windows-subsystem-for-linux-for-intel-gpus/)
 
 ## Custom storage path
 
@@ -96,7 +98,8 @@ To change the storage path for everything you can set environment variable `MMX_
 
 ## Testnet
 
-To run a node on testnet: `echo testnet13 > NETWORK` and restart. \
+To run a node on testnet: `echo testnet13 > NETWORK` and restart.\
 To switch back to mainnet: `rm NETWORK` and restart.
 
-Alternatively, it's possible to run testnet in parallel via docker: https://github.com/madMAx43v3r/mmx-node/tree/master/scripts/docker/mmx-testnet
+Alternatively, it's possible to run testnet in parallel via docker:\
+[mmx-node/scripts/docker/mmx-testnet](https://github.com/madMAx43v3r/mmx-node/tree/master/scripts/docker/mmx-testnet)

--- a/docs/src/content/docs/guides/mmx-plotter.mdx
+++ b/docs/src/content/docs/guides/mmx-plotter.mdx
@@ -3,10 +3,10 @@ title: Plotting Guide
 description: MMX Plotter is a tool for creating plots for the MMX blockchain.
 ---
 
-import { Aside } from '@astrojs/starlight/components';
 import { Tabs, TabItem } from '@astrojs/starlight/components';
 
 ## MMX Plotting
+
 The MMX CUDA plotter is available at [mmx-binaries](https://github.com/madMAx43v3r/mmx-binaries).
 The source code for the plotter can be found at [mmx-cuda-plotter](https://github.com/madMAx43v3r/mmx-cuda-plotter).
 A CUDA GPU is required for plotting due to the compression resistant plot format, since plotting on CPU would take too long.
@@ -14,18 +14,28 @@ The format is compression resistant, but not incompressible. The current plotter
 C10 can be farmed on most modern CPUs while still giving a gain of 3%. Larger capacity hard drives may struggle to seek quickly enough when full of k29 plots. Hence for drives over 16TB k30 is the minimum recommended size.
 
 ### Available k-sizes with plotting requirements
-| K-Size | HDD Size (GiB) | SSD Size (GiB) | Full RAM (GiB) | Partial RAM (GiB) | Disk with Partial RAM (GiB) |
-|:-------|:----------:|:----------:|:--------------:|:-----------------:|:---------------:|
-| K29  |  37    |    15    |      61    |       39      |      22     |
-| K30  |  75    |    30    |     116    |       68      |      46     |
-| K31  |  155   |    62    |     226    |      126      |      88     |
-| K32  |  320   |    128   |     446    |      246      |     177     |
 
-<Aside>All values are for C0 compression and are approximate based on observations while plotting. Due to differences in the tables, final plot sizes may vary significantly. For k32 a difference of 3-4GiB between largest to smallest plot files have been observed.</Aside>
-<Aside>Full RAM, and Partial RAM refer to plotting modes. Disk space is what is needed by `-2` with partial RAM plotting. When using full disk mode plotting, temp space required for `-3` is the same as Partial RAM requirements. If `-3` and `-2` are the same drive, use the Full RAM space as a reference.</Aside>
-<Aside type="caution">The RAM Requirements above were tested to work on linux. Due to quirks of memory usage on Windows OS, it may not be possible to plot k31 in partial ram on a system with 128gb of ram.</Aside>
+| k-size | HDD-size | SSD-size | Full RAM | Partial RAM | Disk/Partial RAM |
+| :--- | :--- | :--- | :--- | :--- | :--- |
+| `k29` | 37 GiB | 15 GiB | 61 GiB | 39 GiB | 22 GiB |
+| `k30` | 75 GiB | 30 GiB | 116 GiB | 68 GiB | 46 GiB |
+| `k31` | 155 GiB | 62 GiB | 226 GiB | 126 GiB | 88 GiB |
+| `k32` | 320 GiB | 128 GiB | 446 GiB | 246 GiB | 177 GiB |
+
+:::note[Note]
+All values are for C0 compression and are approximate based on observations while plotting. Due to differences in the tables, final plot sizes may vary significantly. For k32 a difference of 3-4GiB between largest to smallest plot files have been observed.
+:::
+
+:::note[Note]
+Full RAM, and Partial RAM refer to plotting modes. Disk space is what is needed by `-2` with partial RAM plotting. When using full disk mode plotting, temp space required for `-3` is the same as Partial RAM requirements. If `-3` and `-2` are the same drive, use the Full RAM space as a reference.
+:::
+
+:::caution[Caution]
+The RAM Requirements above were tested to work on linux. Due to quirks of memory usage on Windows OS, it may not be possible to plot k31 in partial ram on a system with 128GB of RAM.
+:::
 
 ## Compression
+
 The MMX CUDA Plotter supports compression levels C0 to C15. Farming compressed plots is currently only supported on CPU.
 However recomputing a full proof on HDD plots is only required when a good enough quality has been found, either to make a block or to make a partial.
 GPU recompute would only add a few extra percent of gains, at the cost of needing a (big) GPU to sit idle most of the time (in case of HDD plots).
@@ -33,18 +43,21 @@ GPU recompute for farming lots of (uncompressed) SSD plots is planned, as this i
 Since SSD plots always need to recompute the proof output hash (quality), meaning the compute load is proportional to number of plots.
 
 ### HDD Plots
+
 C15 is _possible_ to farm on CPU, but only with ~64 cores or more. It is not recommended to use C15 as the gain over C10 is minimal (1.5%).
 C10-C12 can be handled by most modern CPUs. C5 can be farmed on almost any CPU, with minimal power draw.
 When making NFT plots, it is recommended to use a lower C level (3-5 levels lower) since more proofs need to be computed when pooling (one for each partial).
 The compute load when farming HDD plots is independent of the number of plots. The challenge is computing a full proof fast enough to make a block or partial in time.
 
 ### SSD Plots
+
 SSD plots are 2.5x smaller than HDD plots. They cannot be farmed on HDDs (even in a RAID array) due to the high IOPS required to farm them (proportional to plot count).
 The CPU load to farm SSD plots is already quite high with C0, as such C0 is recommended when making SSD plots. Higher k-size reduces CPU and IOPS load.
 As such the most efficient SSD plots are k32 C0, with k29 having 8x higher CPU and IOPS load. k32 C3 is equal to k29 C0 in terms of CPU load.
 Farming 1024 uncompressed SSD plots is the same compute load as computing a single C10 full proof.
 
 ### Benchmark
+
 Before plotting with compression a benchmark should be performed to check if your system can handle it:
 ```bash frame="none"
 mmx_posbench -k 31 -C 10                  # to benchmark k31 C10
@@ -53,10 +66,12 @@ mmx_posbench --devices 1 2 -k 31 -C 10    # to select specific CUDA devices (sta
 ```
 
 ## Creating Plots
+
 To create plots you will need a Farmer Public Key, and optionally a PlotNFT contract address (for NFT plots). To get the Farmer Public Key, see `mmx wallet keys` or go to the `Info` tab under the wallet in the GUI.
 For PlotNFT contract address, see [Pooling](../../software/cli-commands/#pooling).
 
 ### Command Line Reference
+
 To use the plotter via command line, navigate to the directory containing the plotter binaries and run the following command (replace `mmx_cuda_plot_k30` with the appropriate binary for your desired k-size):
 <Tabs>
     <TabItem label="Full RAM">
@@ -82,8 +97,10 @@ To send finished plots to multiple destinations, use the `-d` argument multiple 
 ```bash frame="none"
 ./mmx_cuda_plot_k30 -C 5 -n -1 -t /mnt/tmp_ssd/ -d /mnt/farmdrive1/ -d /mnt/farmdrive2/ -f <farmer_key>
 ```
-<Aside>To simplify sending to multiple destinations over a network, you can use [plot-sink](https://github.com/madMAx43v3r/chia-gigahorse/tree/master/plot-sink).</Aside>
 
+:::note[Note]
+To simplify sending to multiple destinations over a network, you can use [plot-sink](https://github.com/madMAx43v3r/chia-gigahorse/tree/master/plot-sink).
+:::
 
 Full Command Line Reference options:
 

--- a/docs/src/content/docs/guides/optimize-vdf.md
+++ b/docs/src/content/docs/guides/optimize-vdf.md
@@ -2,6 +2,7 @@
 title: OpenCL Setup
 description: How to improve VDF verification speed.
 ---
+
 Using OpenCL is an optional but highly recommended feature for running MMX.\
 Offloading the verification of the VDF to a GPU or iGPU can increase both performance and power efficiency.
 
@@ -15,11 +16,14 @@ If OpenCL is not being utilized for VDF verification, you should see relatively 
 
 If you are running a Timelord (the default is off), you will see high CPU usage on at least one core in any case, even if your GPU is used for verification.
 
-Note: During initial blockchain sync, CPU usage can be high in any case.
+:::note[Note]
+During initial blockchain sync, CPU usage can be high in any case.
+:::
 
-Example Hardware and times spreadsheet: https://docs.google.com/spreadsheets/d/1NlK-dq7vCbX4NHzrOloyy4ylLW-fdXjuT8468__SF64/edit?pli=1&gid=618383284#gid=618383284
+Example Hardware and times [Google spreadsheet](https://docs.google.com/spreadsheets/d/1NlK-dq7vCbX4NHzrOloyy4ylLW-fdXjuT8468__SF64/edit?pli=1&gid=618383284#gid=618383284).
 
 ## OpenCL for Intel iGPUs
+
 Intel iGPUs prior to 11th gen are not sufficient for mainnet. Intel's desktop iGPUs have much fewer compute units than their mobile counterparts, so only the mobile SKUs in laptops/mini-PCs will be suitable for OpenCL VDF verify. 11th gen and newer desktop CPUs with the SHA instruction set can get decent performance on the CPU cores without OpenCL.
 
 Ubuntu 20.04, 21.04
@@ -34,10 +38,9 @@ sudo apt update
 sudo apt install intel-opencl-icd
 ```
 
-If the above doesn't work, you can try installing the latest drivers: https://dgpu-docs.intel.com/installation-guides/ubuntu/ubuntu-focal.html
+If the above doesn't work, you can try installing the latest drivers: [Intel GPU Ubuntu](https://dgpu-docs.intel.com/installation-guides/ubuntu/ubuntu-focal.html)
 
-
-Make sure your iGPU is not somehow disabled, like here for example: https://community.hetzner.com/tutorials/howto-enable-igpu
+Make sure your iGPU is not somehow disabled, like here for example: [Intel Enable iGPU](https://community.hetzner.com/tutorials/howto-enable-igpu)
 
 ## OpenCL for AMD GPUs
 
@@ -71,11 +74,11 @@ Arch:
 sudo pacman -S mesa mesa-utils opencl-mesa
 ```
 
-Windows: https://google.com/search?q=amd+graphics+driver+download
+Windows: [Google search AMD](https://google.com/search?q=amd+graphics+driver+download)
 
 ## OpenCL for Nvidia GPUs
 
-Due to the massive generational leap in compute performance, the Maxwell generation (900 series Geforce, M-series and some K-series Quadro) should be the minimum consideration for Nvidia GPUs. 
+Due to the massive generational leap in compute performance, the Maxwell generation (900 series Geforce, M-series and some K-series Quadro) should be the minimum consideration for Nvidia GPUs.
 
 Install Nvidia drivers:
 
@@ -89,6 +92,7 @@ Version 470 still works with older Kepler cards like a Quadro K2000.
 Use latest version for newer GPUs.
 
 ### Arch Linux
+
 ```bash frame="none"
 sudo pacman -S nvidia nvidia-utils opencl-nvidia
 ```

--- a/docs/src/content/docs/guides/remote-services.md
+++ b/docs/src/content/docs/guides/remote-services.md
@@ -21,7 +21,9 @@ To run a remote harvester:
 ```
 Alternatively to set the node address permanently: `echo node.ip > config/local/node`
 
-Note: To connect to a remote farmer, replace `node.ip` with the farmer IP.
+:::note[Note]
+To connect to a remote farmer, replace `node.ip` with the farmer IP.
+:::
 
 To disable the built-in harvester in the node: `echo false > config/local/harvester`
 
@@ -33,8 +35,8 @@ To run a remote farmer with it's own wallet and harvester:
 ```
 Alternatively to set the node address permanently: `echo node.ip > config/local/node`
 
-To disable the built-in farmer in the node: `echo false > config/local/farmer` \
-To disable the built-in wallet in the node or farmer: `echo false > config/local/wallet` \
+To disable the built-in farmer in the node: `echo false > config/local/farmer`\
+To disable the built-in wallet in the node or farmer: `echo false > config/local/wallet`\
 To disable the built-in harvester in the farmer: `echo false > config/local/harvester`
 
 ### Remote Timelord

--- a/docs/src/content/docs/reference/MMX_wallet.md
+++ b/docs/src/content/docs/reference/MMX_wallet.md
@@ -2,13 +2,14 @@
 title: MMX Wallet
 description: Important information for developing a wallet for MMX.
 ---
+
 ## MMX Wallet / Address Format
 
 Notes for 3rd party development:
 - When converting mnemonic words to a wallet seed, the byte order needs to be reversed, compared to BIP-39.
 - The key derivation function for the passphrase is non-standard:
-	- There is no chain XORing (not needed for sha512)
-	- There is no index being hashed in the first iteration
+  - There is no chain XORing (not needed for sha512)
+  - There is no index being hashed in the first iteration
 - The byte order for bech32 addresses is reversed:
-	- When converting a public key to bech32, first the sha256 hash is computed, then the byte order is reversed and converted with standard Bech32m.
-	- When converting a bech32 address to a hash, the bytes from the resulting standard Bech32m decode need to be reversed.
+  - When converting a public key to bech32, first the sha256 hash is computed, then the byte order is reversed and converted with standard Bech32m.
+  - When converting a bech32 address to a hash, the bytes from the resulting standard Bech32m decode need to be reversed.

--- a/docs/src/content/docs/reference/blockchain.md
+++ b/docs/src/content/docs/reference/blockchain.md
@@ -8,7 +8,7 @@ A blockchain written from scratch, doing most things differently.
 2. Variable supply will stabilize the price, key property of any currency
 3. Efficient implementation provides low transaction fees, at high throughput
 
-:::note
+:::note[Note]
 In-depth technical, read [whitepaper](../../../articles/general/mmx-whitepaper/). Light introduction, read [article](../../../articles/general/mmx-tldr/).
 :::
 

--- a/docs/src/content/docs/reference/pooling_protocol.md
+++ b/docs/src/content/docs/reference/pooling_protocol.md
@@ -2,6 +2,7 @@
 title: Pooling Protocol
 description: MMX Pooling Protocol reference.
 ---
+
 ## Notes
 - MMX addresses are encoded via bech32 string
 - Hashes and signatures are encoded via little-endian upper-case hex string, without `0x` prefix
@@ -46,6 +47,7 @@ Returns status 200 with `application/json` object as follows:
 - `error_message`: Message string
 
 #### Example partial
+
 TODO: update
 ```
 {
@@ -147,17 +149,18 @@ Returns account info as `application/json` object:
 
 Endpoint to verify a partial, optionally with plot NFT verification.
 
-Note:
+:::note[Note]
 Partials should be verfied after a certain delay, for example once the height of the partial has been reached on-chain.
 Partials are computed 6 blocks in advance, so waiting until the partial's height has been reached will give 6 blocks security.
 Even in case of a re-org larger than 6 blocks, the chance a partial won't be valid anymore is only ~5%.
+:::
 
 Content-Type: `application/json`
 
 Payload: Object
 - `partial`: The same object as was received by the pool via POST `/partial`.
 - `pool_target`: Expected plot NFT target address (optional)
-	- When specified will verify plot NFT is locked to given target address at current blockchain height.
+  - When specified will verify plot NFT is locked to given target address at current blockchain height.
 
 Returns status 200 with `application/json` object as follows:
 - `error_code`: Integer error code (see below)
@@ -187,13 +190,14 @@ A string is generated for JSON objects as follows:
 
 - First the `__type` field is added, followed with `/`
 - Then for each field in the specified order:
-	- The field name is added, followed with a `:`
-	- The field value is added (floating point values are floored first)
+  - The field name is added, followed with a `:`
+  - The field value is added (floating point values are floored first)
 - For any nested objects, the same scheme is followed.
 
 The final string is hashed via `SHA2-256`.
 
 ## Error Codes
+
 Error codes are transferred as strings in JSON:
 - `NONE`: No error
 - `INVALID_PARTIAL`
@@ -211,8 +215,3 @@ Error codes are transferred as strings in JSON:
 - `INVALID_TIMESTAMP`
 - `POOL_LOST_SYNC`
 - `SERVER_ERROR`
-
-
-
-
-

--- a/docs/src/content/docs/software/MMX_script.md
+++ b/docs/src/content/docs/software/MMX_script.md
@@ -2,6 +2,7 @@
 title: MMX Script
 description: MMX Script smart contract language reference.
 ---
+
 The MMX smart contract language is a restricted subset of JavaScript with some additional features.
 
 ## Types
@@ -14,7 +15,9 @@ The MMX smart contract language is a restricted subset of JavaScript with some a
 - Array
 - Map
 
-Note: Objects are maps with string keys.
+:::note[Note]
+Objects are maps with string keys.
+:::
 
 ## Deviations from JavaScript
 
@@ -49,42 +52,42 @@ Note: Objects are maps with string keys.
 - Multiple assignment: `[a, b] = arr, {a, b} = obj`
 - Spread syntax `(...)`
 - Any built-in classes like:
-	- `Array`, `Map`, `Set`, `Time`, `Date`, `Number`, `Math`
-	- `Error`, `Object`, `Function`, `Boolean`, `Symbol`
-	- `String`, `RegExp`, `Promise`, `Iterator`, `Proxy`
+  - `Array`, `Map`, `Set`, `Time`, `Date`, `Number`, `Math`
+  - `Error`, `Object`, `Function`, `Boolean`, `Symbol`
+  - `String`, `RegExp`, `Promise`, `Iterator`, `Proxy`
 - Any built-in functions like:
-	- `eval()`, `escape()`, `unescape()`
+  - `eval()`, `escape()`, `unescape()`
 
 ## Additional features
 
 - `const` function modifier
-	- `function get_price() const {}`
-	- `const` functions cannot modify contract state
+  - `function get_price() const {}`
+  - `const` functions cannot modify contract state
 - `static` function modifier
-	- `function init_ex(...) static {}`
-	- Denotes that function is a constructor (executes static init first)
-	- Any `init()` function is implicitly static
+  - `function init_ex(...) static {}`
+  - Denotes that function is a constructor (executes static init first)
+  - Any `init()` function is implicitly static
 - `public` function modifier
-	- `function payout() public {}`
-	- Only public functions can be executed via transactions.
+  - `function payout() public {}`
+  - Only public functions can be executed via transactions.
 - `payable` function modifier
-	- `function trade(...) public payable {}`
-	- Required to support deposits with function call.
-	- A `deposit()` function is always `payable`.
+  - `function trade(...) public payable {}`
+  - Required to support deposits with function call.
+  - A `deposit()` function is always `payable`.
 
 - Special `this` object to access built-in variables:
-	- `txid`: The transaction ID (Type: 32-bytes or `null`)
-	- `height`: The block height at which the code is executed (Type: 256-bit unsigned int)
-	- `balance`: Map of contract balances (Type: Map[32-bytes] = 256-bit unsigned int)
-		- Returns `0` in case of missing balance entry (instead of `null`).
-	- `address`: Contract address (Type: 32-bytes)
-	- `user`: A user address can be specified when executing a contract function,
-		which is verified via a signature before executution, same as `msg.sender` in EVM.
-		In case of a remote call this is the address of the caller's contract.
-		(Type: 32-bytes or `null`)
-	- `deposit`: Object to check for deposited currency and amount (for `payable` functions):
-		- `currency`: Currency address (Type: 32-bytes)
-		- `amount`: Amount deposited (Type: 256-bit unsinged int)
+  - `txid`: The transaction ID (Type: 32-bytes or `null`)
+  - `height`: The block height at which the code is executed (Type: 256-bit unsigned int)
+  - `balance`: Map of contract balances (Type: Map[32-bytes] = 256-bit unsigned int)
+    - Returns `0` in case of missing balance entry (instead of `null`).
+  - `address`: Contract address (Type: 32-bytes)
+  - `user`: A user address can be specified when executing a contract function,
+    which is verified via a signature before executution, same as `msg.sender` in EVM.
+    In case of a remote call this is the address of the caller's contract.
+    (Type: 32-bytes or `null`)
+  - `deposit`: Object to check for deposited currency and amount (for `payable` functions):
+    - `currency`: Currency address (Type: 32-bytes)
+    - `amount`: Amount deposited (Type: 256-bit unsinged int)
 
 ## Operators (sorted by rank)
 
@@ -134,91 +137,91 @@ Note: Objects are maps with string keys.
 - `clone(v)`: Makes a (deep) copy and returns reference
 - `deref(v)`: Returns a (deep) copy (without reference) of the value given by a reference
 - `typeof(v)`: Returns an integer to denote a variable's type:
-	- 0 = `null`
-	- 1 = `false`
-	- 2 = `true`
-	- 4 = Integer (256-bit unsinged)
-	- 5 = String
-	- 6 = Binary
-	- 7 = Array
-	- 8 = Map
+  - 0 = `null`
+  - 1 = `false`
+  - 2 = `true`
+  - 4 = Integer (256-bit unsinged)
+  - 5 = String
+  - 6 = Binary
+  - 7 = Array
+  - 8 = Map
 - `concat(a, b, [...])`: Returns concatenation of two or more (binary) strings (like `a + b + ...` in JS)
 - `memcpy(src, count, [offset])`
-	- Returns a sub-string of `src` with length `count` starting at `offset`
-	- `offset` defaults to `0`
-	- `src` must be a string or binary string
-	- Out of bounds access will fail execution
+  - Returns a sub-string of `src` with length `count` starting at `offset`
+  - `offset` defaults to `0`
+  - `src` must be a string or binary string
+  - Out of bounds access will fail execution
 - `fail(message, [code])`: Fails execution with string `message` and optional integer `code`
 - `assert(condition, [message], [code])`: Fails execution if `condition` does not evaluate `true`
-	- If `message` is not specified, it will print source code instead.
+  - If `message` is not specified, it will print source code instead.
 - `bech32(addr)`: Parses a bech32 address string and returns 32 bytes.
-	- Returns 32 zero bytes if no argument given, which corresponds to the zero address.
+  - Returns 32 zero bytes if no argument given, which corresponds to the zero address.
 - `binary(v)`: Converts to a binary
-	- Returns binary for strings (1-to-1 copy)
-	- Returns little endian 32-byte binary for integers
+  - Returns binary for strings (1-to-1 copy)
+  - Returns little endian 32-byte binary for integers
 - `binary_le(v)`: Same as `binary()` except:
-	- Returns big endian 32-byte binary for integers
+  - Returns big endian 32-byte binary for integers
 - `binary_hex(v)`: Same as `binary()` except:
-	- Parses input string as a hex string, with optional `0x` prefix.
+  - Parses input string as a hex string, with optional `0x` prefix.
 - `bool(v)`: Converts to boolean
-	- Returns `false` for: `null`, `false`, `0`, empty (binary) string
-	- Otherwise returns `true`
+  - Returns `false` for: `null`, `false`, `0`, empty (binary) string
+  - Otherwise returns `true`
 - `uint(v)`: Converts to 256-bit unsigned integer
-	- `null` => 0, `false` => 0, `true` => 1
-	- `"123"` => 123, `"0b10"` => 2, `"0xFf"` => 255
-	- Binary strings are parsed in big endian: `[00, FF]` => `0x00FF` / `255`
+  - `null` => 0, `false` => 0, `true` => 1
+  - `"123"` => 123, `"0b10"` => 2, `"0xFf"` => 255
+  - Binary strings are parsed in big endian: `[00, FF]` => `0x00FF` / `255`
 - `uint_le(v)`: Same as `uint()` except binary strings are parsed in little endian.
 - `uint_hex(v)`: Same as `uint()` except strings are parsed in hex, even without `0x` prefix.
 - `string(v)`: Converts to a string
-	- Integers are converted to decimal
-	- String inputs are returned as-is
-	- Binary strings are converted as-is (like memcpy())
+  - Integers are converted to decimal
+  - String inputs are returned as-is
+  - Binary strings are converted as-is (like memcpy())
 - `string_hex(v)`: Same as `string()` except:
-	- Converts integers and binary strings to a hex string, without `0x` prefix.
+  - Converts integers and binary strings to a hex string, without `0x` prefix.
 - `string_bech32(v)`: Same as `string()` except:
-	- Converts binary string to a bech32 address string `mmx1...` (fails if not 32 bytes)
-	- Converts `null` to zero address string `mmx1qqqq...`
+  - Converts binary string to a bech32 address string `mmx1...` (fails if not 32 bytes)
+  - Converts `null` to zero address string `mmx1qqqq...`
 - `is_uint(v)`: Returns `true` if argument is of type integer
 - `is_string(v)`: Returns `true` if argument is of type string
 - `is_binary(v)`: Returns `true` if argument is of type binary
 - `is_array(v)`: Returns `true` if argument is of type array
 - `is_map(v)`: Returns `true` if argument is of type map
 - `balance([currency])`: Returns current balance for given currency (for the contract)
-	- `currency` defaults to MMX if not specified (32-byte binary)
+  - `currency` defaults to MMX if not specified (32-byte binary)
 - `send(address, amount, [currency], [memo])`: Transfer funds from contract to an address
-	- `address` is destination address as 32-byte binary
-	- `amount` is integer amount, fails if larger than 64-bit
-	- `currency` is currency address as 32-byte binary, defaults to MMX (ie. `bech32()`)
-	- `memo` is an optional memo string (fails if longer than 64 chars)
-	- Does nothing if `amount` is zero
-	- Fails if balance is insufficient
-	- Returns `null` (ie. nothing)
+  - `address` is destination address as 32-byte binary
+  - `amount` is integer amount, fails if larger than 64-bit
+  - `currency` is currency address as 32-byte binary, defaults to MMX (ie. `bech32()`)
+  - `memo` is an optional memo string (fails if longer than 64 chars)
+  - Does nothing if `amount` is zero
+  - Fails if balance is insufficient
+  - Returns `null` (ie. nothing)
 - `mint(address, amount, [memo])`: Mint new tokens of contract and send to address
-	- `address` is destination address as 32-byte binary
-	- `amount` is integer amount, fails if larger than 64-bit
-	- `memo` is an optional memo string (fails if longer than 64 chars)
-	- Does nothing if `amount` is zero
-	- Returns `null` (ie. nothing)
-	- This is the only way to mint tokens on MMX blockchain
+  - `address` is destination address as 32-byte binary
+  - `amount` is integer amount, fails if larger than 64-bit
+  - `memo` is an optional memo string (fails if longer than 64 chars)
+  - Does nothing if `amount` is zero
+  - Returns `null` (ie. nothing)
+  - This is the only way to mint tokens on MMX blockchain
 - `sha256(msg)`: Computes SHA-2 256-bit hash for given input message (binary or string)
-	- Returns hash as 32 bytes
+  - Returns hash as 32 bytes
 - `ecdsa_verify(msg, pubkey, signature)`: Verifies a ECDSA signature
-	- Returns `true` if valid, otherwise `false`
-	- `msg` must be 32 bytes
-	- `pubkey` must be 33 bytes
-	- `signature` must be 64 bytes
+  - Returns `true` if valid, otherwise `false`
+  - `msg` must be 32 bytes
+  - `pubkey` must be 33 bytes
+  - `signature` must be 64 bytes
 - `rcall(contract, method, [arg0], [arg1], ...)`: Calls function of another contract and returns value
-	- `contract` is a string idendifier of the contract to call (specified at deploy time)
-	- `method` is the method name as string (without `()`)
-	- Returns value from the function call
+  - `contract` is a string idendifier of the contract to call (specified at deploy time)
+  - `method` is the method name as string (without `()`)
+  - Returns value from the function call
 - `read(field, [address])`:
-	- Returns the value of a non-storage contract field (which is constant)
-	- `address` is current contract if not specified
-	- Storage fields cannot be read with this function, need to use `rcall()` instead
+  - Returns the value of a non-storage contract field (which is constant)
+  - `address` is current contract if not specified
+  - Storage fields cannot be read with this function, need to use `rcall()` instead
 - `log(level, message)`: For debugging / testing only
-	- Logs a string message at integer `level`
+  - Logs a string message at integer `level`
 - `event(name, data)`: For debugging / testing only
-	- Logs an event with string `name` and arbitrary `data`
+  - Logs an event with string `name` and arbitrary `data`
 - `__nop()`: Injects an `OP_NOP` instruction (for debugging)
 - `__copy(dst, src)`: Same as `dst = src` but bypasses compiler const check on `dst` for debugging.
 
@@ -228,7 +231,7 @@ Because floating point values and arithmetic are not supported, one has to use f
 
 First you need to choose how much precision is needed.
 A good choice would be 64-bits or 96-bits, such that a 256-bit overflow is not possible when adding a lot of 128-bit values.
-Account balances can be up to 128-bit, while amounts (for deposit and sending) are limited to 64-bit. 
+Account balances can be up to 128-bit, while amounts (for deposit and sending) are limited to 64-bit.
 
 Let's say we choose 64-bit precision.
 This means we multiply all constants by 2^64 (or left shift by 64) and right shift by 64 to get a result.
@@ -290,30 +293,33 @@ Any global variable will be persisted accross the lifetime of a contract:
 ```js
 var storage = [];
 function add(value) public {
-	push(storage, value);
+  push(storage, value);
 }
 function get() const public {
-	return storage;
+  return storage;
 }
 ```
 
 ### Constructor
 
-Any `static` private function can be a constructor. When deploying a contract you have to specify which function to use. \
+Any `static` private function can be a constructor. When deploying a contract you have to specify which function to use.\
 The default is to use `init()`:
 ```js
 var foo;
 var spec;
 function init(bar) {
-	foo = bar;
+  foo = bar;
 }
 function init_v(bar, v) static {
-	foo = bar;
-	spec = v;
+  foo = bar;
+  spec = v;
 }
 ```
-Note: `init()` is always marked as `static`.\
-Note: Global variables are initialized to `null` before constructor is executed.
+
+:::note[Note]
+`init()` is always marked as `static`.\
+Global variables are initialized to `null` before constructor is executed.
+:::
 
 ### Deposit
 
@@ -322,14 +328,17 @@ Deposits in MMX are made through function calls to a `payable` function:
 var currency = bech32();
 var balances = {};
 function deposit(account) public payable {
-	if(this.deposit.currency != currency) {
-		fail("invalid currency");
-	}
-	balances[account] += this.deposit.amount;
+  if(this.deposit.currency != currency) {
+    fail("invalid currency");
+  }
+  balances[account] += this.deposit.amount;
 }
 ```
-Note: If a function is called "deposit" the `payable` modifier can be omitted.
-Note: `this.balance` already includes the deposited amount, it always equals the amount that can be spent via `send()`.
+
+:::note[Note]
+If a function is called "deposit" the `payable` modifier can be omitted.\
+`this.balance` already includes the deposited amount, it always equals the amount that can be spent via `send()`.
+:::
 
 Trying to deposit funds via a non-`payable` function is not possible.
 However it's possible to send funds to a contract via normal transfer.
@@ -344,33 +353,33 @@ This allows a more efficient way to deploy with funding, compared to executing a
 ### Built-in Contracts
 
 - [offer.js](https://github.com/madMAx43v3r/mmx-node/tree/master/src/contract/offer.js) - Offer
-	- Allows to trade between two currencies at a fixed price (See GUI -> Market)
-	- Takers can trade any fraction of the offer
-	- Maker can cancel / refill at any time
-	- Bids are accumulated in the contract (for lower tx fees)
-	- Manual withdrawal will transfer accumulated bids to maker wallet
+  - Allows to trade between two currencies at a fixed price (See GUI -> Market)
+  - Takers can trade any fraction of the offer
+  - Maker can cancel / refill at any time
+  - Bids are accumulated in the contract (for lower tx fees)
+  - Manual withdrawal will transfer accumulated bids to maker wallet
 - [swap.js](https://github.com/madMAx43v3r/mmx-node/tree/master/src/contract/swap.js) - Swap
-	- Liquidity pool AMM, similar to UniSwap (see GUI -> Swap)
-	- Has 4 different fee-tiers, each with their own liquidty and price
-	- A trade is divided into multiple chunks / iterations
-	- `trade()` loops over all pools in multiple iterations and picks the best pool to trade with for each chunk (while taking the fee into account)
-	- Supports one-sided liquidity
-	- Liquidity is locked for 24 hours after it's been added / or fee-tier was changed
-	- A single account can only provide liquidity for one fee-tier
-	- Fee payouts are heuristic for better trade efficiency (manual trigger, no automatic compounding)
+  - Liquidity pool AMM, similar to UniSwap (see GUI -> Swap)
+  - Has 4 different fee-tiers, each with their own liquidty and price
+  - A trade is divided into multiple chunks / iterations
+  - `trade()` loops over all pools in multiple iterations and picks the best pool to trade with for each chunk (while taking the fee into account)
+  - Supports one-sided liquidity
+  - Liquidity is locked for 24 hours after it's been added / or fee-tier was changed
+  - A single account can only provide liquidity for one fee-tier
+  - Fee payouts are heuristic for better trade efficiency (manual trigger, no automatic compounding)
 - [plot_nft.js](https://github.com/madMAx43v3r/mmx-node/tree/master/src/contract/plot_nft.js) - Plot NFT
-	- Used for pooled farming to control rewards / switch pools
+  - Used for pooled farming to control rewards / switch pools
 - [token.js](https://github.com/madMAx43v3r/mmx-node/tree/master/src/contract/token.js) - Simple Token
-	- Token contract with single owner to mint a token (without limits)
+  - Token contract with single owner to mint a token (without limits)
 - [nft.js](https://github.com/madMAx43v3r/mmx-node/tree/master/src/contract/nft.js) - NFT
-	- Contract used to mint NFTs
-	- Ensures only a single token is ever minted by a verified creator
+  - Contract used to mint NFTs
+  - Ensures only a single token is ever minted by a verified creator
 - [time_lock.js](https://github.com/madMAx43v3r/mmx-node/tree/master/src/contract/time_lock.js) - Simple Time Lock
 - [escrow.js](https://github.com/madMAx43v3r/mmx-node/tree/master/src/contract/escrow.js) - Simple Escrow with middle-man
 
 ### Minting tokens
 
-Minting tokens is only possible via calling `mint()`, which mints new tokens of the contract. \
+Minting tokens is only possible via calling `mint()`, which mints new tokens of the contract.\
 Every contract is also a currency, contract address = currency address.
 
 A smart contract inherits from `mmx.contract.TokenBase`, which has the following fields:
@@ -396,17 +405,17 @@ mmx wallet deploy example.dat
 `mmx_compile` returns the binary address that we need to sepecify when deploying a contract later.
 `-n testnet12` can be omitted for mainnet.
 
-Once the binary is confirmed on-chain, we can deploy any number of contracts with the same code. \
+Once the binary is confirmed on-chain, we can deploy any number of contracts with the same code.\
 This can be done via JSON files:
 ```json
 {
-	"__type": "mmx.contract.Executable",
-	"name": "Example",
-	"symbol": "EXMPL",
-	"decimals": 6,
-	"binary": "mmx1...",
-	"init_method": "init",
-	"init_args": [...]
+  "__type": "mmx.contract.Executable",
+  "name": "Example",
+  "symbol": "EXMPL",
+  "decimals": 6,
+  "binary": "mmx1...",
+  "init_method": "init",
+  "init_args": [...]
 }
 ```
 If the contract does not represent a token, `name`, `symbol` and `decimals` can be omitted.
@@ -502,13 +511,13 @@ That means "copying" by assignment does not make a deep copy, it only copies the
 const array = [1, 2, 3];
 const tmp = array;
 push(tmp, 4);
-return array;	// returns [1, 2, 3, 4]
+return array;  // returns [1, 2, 3, 4]
 ```
 ```js
 const object = {"foo": {}};
 const foo = object.foo;
 foo.bar = true;
-return object;	// returns {foo: {"bar": true}}
+return object;  // returns {foo: {"bar": true}}
 ```
 In order to make a deep-copy you need to use `clone()`.
 
@@ -518,7 +527,7 @@ It's not possible to clone maps / objects from contract storage:
 ```js
 var object = {};
 function test() public {
-	return clone(object);		// will fail
+  return clone(object);  // will fail
 }
 ```
 
@@ -532,7 +541,9 @@ not other contracts or addresses (since that would break parallel execution).
 However it's possible to call a method of another contract that returns its balance.
 In this case execution is serialized.
 
-Note: `this.balance` is updated automatically when receiving funds via deposit, or when spending via `send()`.
+:::note[Note]
+`this.balance` is updated automatically when receiving funds via deposit, or when spending via `send()`.
+:::
 
 ### Instruction costs
 

--- a/docs/src/content/docs/software/RPC_protocol.md
+++ b/docs/src/content/docs/software/RPC_protocol.md
@@ -16,9 +16,9 @@ Authentication is required to access private API endpoints or remove limits from
 The best way to setup static authentication is to create an API token, by editing `config/local/HttpServer.json`:
 ```json
 {
-	"token_map": [
-		["secure_random_token_here", "ADMIN"]
-	]
+  "token_map": [
+    ["secure_random_token_here", "ADMIN"]
+  ]
 }
 ```
 A secure random token can be generated with the `generate_passwd` tool.
@@ -98,7 +98,7 @@ Returns transaction info object (see [tx_info_t.vni](https://github.com/madMAx43
 
 #### GET /wapi/transactions
 
-Returns array of most recent transaction info objects, or list of transaction info objects for a given block height. 
+Returns array of most recent transaction info objects, or list of transaction info objects for a given block height.
 
 Query parameters:
 - `limit`: Result limit (default = 100)
@@ -213,7 +213,6 @@ Example: `POST /wapi/contract/call?id=mmx1...&method=get_price` with content:
 {"args": [0]}
 ```
 
-
 #### GET /wapi/farmers
 
 Query parameters:
@@ -254,7 +253,9 @@ Returns status 400 with error message in case static validation failed, for exam
 - Invalid signature
 - Insufficient balance for TX fee
 
-Note: Clients must handle `nonce` field as a 64-bit integer, truncation will cause static failure.
+:::note[Note]
+Clients must handle `nonce` field as a 64-bit integer, truncation will cause static failure.
+:::
 
 #### POST /wapi/transaction/broadcast
 
@@ -267,18 +268,18 @@ Returns status 200 on success.
 Common parameters:
 - `index`: Wallet index, see `/wapi/wallet/accounts` or `mmx wallet accounts`.
 - `options`: Object with additional options:
-	- `auto_send`: If to send transaction automatically (default = true)
-	- `mark_spent`: If to mark transaction as spent in cache (default = false)
-	- `fee_ratio`: TX fee ratio as integer (default = 1024)
-	- `gas_limit`: Limit for extra dynamic cost (default = 5 MMX)
-	- `expire_at`: Optional expiration height
-	- `expire_delta`: Expiration delta, relative to current height (default = 100, `null` to disable)
-	- `nonce`: Custom nonce (needs be > 0)
-	- `user`: Custom user for contract calls (default = first address)
-	- `sender`: Custom sender address (who will pay TX fee, default = first address)
-	- `passphrase`: Optional passphrase to atomically unlock wallet.
-	- `note`: Transaction note, see [tx_note_e.vni](https://github.com/madMAx43v3r/mmx-node/blob/master/interface/tx_note_e.vni).
-	- `memo`: Optional memo string (max. 64 chars)
+  - `auto_send`: If to send transaction automatically (default = true)
+  - `mark_spent`: If to mark transaction as spent in cache (default = false)
+  - `fee_ratio`: TX fee ratio as integer (default = 1024)
+  - `gas_limit`: Limit for extra dynamic cost (default = 5 MMX)
+  - `expire_at`: Optional expiration height
+  - `expire_delta`: Expiration delta, relative to current height (default = 100, `null` to disable)
+  - `nonce`: Custom nonce (needs be > 0)
+  - `user`: Custom user for contract calls (default = first address)
+  - `sender`: Custom sender address (who will pay TX fee, default = first address)
+  - `passphrase`: Optional passphrase to atomically unlock wallet.
+  - `note`: Transaction note, see [tx_note_e.vni](https://github.com/madMAx43v3r/mmx-node/blob/master/interface/tx_note_e.vni).
+  - `memo`: Optional memo string (max. 64 chars)
 
 Endpoints that send a transaction will first validate it, and if invalid sending is aborted (saving TX fees).
 
@@ -341,7 +342,9 @@ Returns an array of objects:
 - `decimals`: Number of decimals
 - etc
 
-Note: This endpoint includes pending transactions, `is_pending` or `height` needs to be checked.
+:::note[Note]
+This endpoint includes pending transactions, `is_pending` or `height` needs to be checked.
+:::
 
 #### GET /wapi/wallet/tx_history
 
@@ -401,7 +404,9 @@ Request payload is an object of arguments:
 
 Returns status 200 if successful.
 
-Note: Clients must handle `nonce` field as a 64-bit integer, truncation will cause static failure.
+:::note[Note]
+Clients must handle `nonce` field as a 64-bit integer, truncation will cause static failure.
+:::
 
 #### POST /wapi/wallet/deploy
 
@@ -417,12 +422,12 @@ Returns contract address (bech32) if successful.
 Example `payload` for a smart contract:
 ```json
 {
-	"__type": "mmx.contract.Executable",
-	"name": "Fake Testnet USD",
-	"symbol": "USDM",
-	"decimals": 4,
-	"binary": "mmx17pzl9cgmesyjur7rvvev70fx7f55rvyv7549cvrtf7chjml4qh4sryu9yl",
-	"init_args": ["mmx1kx69pm743rshqac5lgcstlr8nq4t93hzm8gumkkxmp5y9fglnkes6ve09z"]
+  "__type": "mmx.contract.Executable",
+  "name": "Fake Testnet USD",
+  "symbol": "USDM",
+  "decimals": 4,
+  "binary": "mmx17pzl9cgmesyjur7rvvev70fx7f55rvyv7549cvrtf7chjml4qh4sryu9yl",
+  "init_args": ["mmx1kx69pm743rshqac5lgcstlr8nq4t93hzm8gumkkxmp5y9fglnkes6ve09z"]
 }
 ```
 
@@ -439,15 +444,3 @@ Request payload is an object of arguments:
 - `options`: Object with options
 
 Returns transaction object if successful.
-
-
-
-
-
-
-
-
-
-
-
-

--- a/docs/src/content/docs/software/cli-commands.md
+++ b/docs/src/content/docs/software/cli-commands.md
@@ -2,6 +2,7 @@
 title: CLI Commands
 description: MMX Node CLI Command Reference.
 ---
+
 When compiled from source:
 ```bash frame="none"
 cd mmx-node
@@ -11,8 +12,8 @@ With a binary package install, just open a new terminal. On Windows search for `
 
 To run any `mmx` commands (except `mmx wallet create`), the node needs to be running. See [Getting Started](../../guides/getting-started/) to read on how to start it.
 
-
 ## Node CLI
+
 To check on the node: `mmx node info`
 
 To check on the peers: `mmx node peers`
@@ -61,8 +62,8 @@ To force a re-sync: `mmx node sync`
 
 To replay/revert to an earlier block height: `mmx node revert <height>`
 
-
 ## Wallet CLI
+
 To show everything in a wallet: `mmx wallet show`
 
 To show wallet balances: `mmx wallet show balance`
@@ -87,10 +88,10 @@ To show recent wallet activity : `mmx wallet log -N <limit>`
 
 To transfer funds: `mmx wallet send <options>`
 ```
-	-a <amount to send, 1.23>
-	-r <tx fee multiplier>
-	-t <destination address>
-	-x <currency>
+  -a <amount to send, 1.23>
+  -r <tx fee multiplier>
+  -t <destination address>
+  -x <currency>
 ```
 To withdraw funds from a contract: `mmx wallet send_from -s <address>`
 
@@ -98,17 +99,17 @@ To transfer an NFT, same as sending with one satoshi: `mmx wallet transfer`
 
 To create an offer on the chain: `mmx wallet offer`
 ```
-	(-x / -z default MMX)
-	-a <bid amount> -b <ask amount>
-	-x <bid currency> -z <ask currency>
+  (-x / -z default MMX)
+  -a <bid amount> -b <ask amount>
+  -x <bid currency> -z <ask currency>
 ```
 To accept an offer: `mmx wallet accept <address>`
 
 To mint tokens: `mmx wallet mint`
 ```
-	-a <amount>
-	-t <destination>
-	-x <currency>
+  -a <amount>
+  -t <destination>
+  -x <currency>
 ```
 To deploy a contract: `mmx wallet deploy <file>`
 
@@ -116,9 +117,9 @@ To execute a smart contract function: `mmx wallet exec <function> <args> -x <con
 
 To deposit funds to a smart contract: `mmx wallet deposit <function> <args>`
 ```
-	-a <amount to send, 1.23>
-	-t <contract address>
-	-x <currency>
+  -a <amount to send, 1.23>
+  -t <contract address>
+  -x <currency>
 ```
 
 To create a new wallet (offline): `mmx wallet create -f [file_name] [--with-passphrase]`
@@ -139,8 +140,8 @@ To unlock a wallet with passphrase: `mmx wallet unlock`
 
 **To use a non-default wallet, specify `-j <index>` in combination with the above commands. See `mmx wallet accounts`.**
 
-
 ## Farmer CLI
+
 To check on the farm: `mmx farm info`
 
 To get total space in bytes: `mmx farm get space`
@@ -153,8 +154,8 @@ To remove plot directories: `mmx farm remove <dir>`
 
 To reload plots: `mmx farm reload`
 
-
 ## Harvester CLI
+
 To check on the harvester: `mmx harvester info`
 
 To get harvester space in bytes: `mmx harvester get space`
@@ -168,6 +169,7 @@ To remove plot directories: `mmx harvester remove <dir>`
 To reload plots: `mmx harvester reload`
 
 ## Pooling
+
 To use pooling first create a plot NFT, then create plots for it and finally join a pool.
 
 ### Create Plot NFT
@@ -181,8 +183,10 @@ mmx wallet plotnft create <name>
 After creation the plot NFT is in solo farming mode, which means block rewards will directly go to your Farmer reward address.
 See below how to join a pool.
 
-Note: Need to wait for the transaction to confirm before it will show up.\
-Note: This command takes the usual `-j <index>` argument to select a different wallet.
+:::note[Note]
+Need to wait for the transaction to confirm before it will show up.\
+This command takes the usual `-j <index>` argument to select a different wallet.
+:::
 
 ### Show Plot NFTs
 
@@ -192,7 +196,9 @@ mmx wallet plotnft show
 
 The address shown in `[...]` is the plot NFT contract address, which needs to be used for plotting.
 
-Note: This command takes the usual `-j <index>` argument to select a different wallet.
+:::note[Note]
+This command takes the usual `-j <index>` argument to select a different wallet.
+:::
 
 Example:
 ```bash frame="none"
@@ -206,6 +212,7 @@ mmx wallet plotnft show -j 1
 ```
 
 ### Join a Pool
+
 First you need to obtain the pool server URL for the pool, via their website or discord.
 
 ```bash frame="none"
@@ -214,7 +221,9 @@ mmx wallet plotnft join <pool_url> -x <plot_nft_address>
 
 `<plot_nft_address>` is the same as used for plotting, see `mmx wallet plotnft show`.
 
-Note: This command does not need any `-j` to select a wallet.
+:::note[Note]
+This command does not need any `-j` to select a wallet.
+:::
 
 Example:
 ```bash frame="none"
@@ -230,7 +239,9 @@ mmx wallet plotnft unlock -x <plot_nft_address>
 This will take 256 blocks to complete, to avoid cheating.
 Once complete the plot NFT is in solo farming mode, which means block rewards will directly go to your Farmer reward address.
 
-Note: This command does not need any `-j` to select a wallet.
+:::note[Note]
+This command does not need any `-j` to select a wallet.
+:::
 
 Example:
 ```bash frame="none"
@@ -238,9 +249,11 @@ mmx wallet plotnft unlock -x mmx1wknv8xxvzjafrswsrwr3l85y6d8nms2dz22dgxl2qpcyjp6
 ```
 
 ### Switch Pool
+
 First leave the current pool, wait 256 blocks for the plot NFT to unlock, then join the new pool as shown above.
 
 ### Show Info
+
 To see pool account: `mmx pool info`
 
 To see partials info: `mmx farm info`

--- a/docs/src/content/docs/software/web_wallet_api.md
+++ b/docs/src/content/docs/software/web_wallet_api.md
@@ -12,7 +12,7 @@ Even though the wallet can have multiple accounts or addresses, only one is acti
 Returns the (currently active) wallet address in bech32 format.
 
 Keep in mind this address can be spoofed by the wallet.
-To make sure the user actually owns this address you need to have them sign a random message via `sign_message(msg)` and verify the signature. 
+To make sure the user actually owns this address you need to have them sign a random message via `sign_message(msg)` and verify the signature.
 
 ### get_public_key()
 


### PR DESCRIPTION
PR for align/clean markdown syntax, Docs

**Goal:** Get syntax/markdown style coherent. Future edits/adds deviates less.

**Deploy Preview:** **[https://deploy-preview-311--mmx-docs.netlify.app](https://deploy-preview-311--mmx-docs.netlify.app)**

Changes:
- No real content/text change
  - Except a few, when certain, no message/meaning change
- Align/clean of syntax/markdown
  - Rework logical text notes to aside(:::) colored square
  - All tabs to 2x spaces (less problems/issues in markdown)
    - Even though 2-bytes vs 1-byte 'space/storage' ;-)
  - Unneeded spaces/lines trimmed
  - Empty line before/after all headings(#) (syntax readability)
  - FullURLs reworked to shorter link text (same URL)

Ready for merge, from my side.