### PR TITLE
Fix: offer table shows fractional amounts for 0-decimal tokens

### DIFF
--- a/www/web-gui/public/market.js
+++ b/www/web-gui/public/market.js
@@ -542,7 +542,7 @@ Vue.component('market-offers', {
 									</template>
 								</td>
 								<td>
-									<b>{{parseFloat((item.bid_balance_value * item.display_price).toPrecision(6))}}</b>&nbsp;
+									<b>{{item.ask_value}}</b>&nbsp;
 									<template v-if="item.ask_symbol == 'MMX'">MMX</template>
 									<template v-else>
 										<router-link :to="'/explore/address/' + item.ask_currency">


### PR DESCRIPTION
## Bug

The **All Offers** table in the web GUI (`market.js`) displays incorrect fractional amounts for tokens with 0 decimals. The API already returns the correct integer value in `ask_value`, but the GUI ignores it and recomputes via floating-point math, producing values like `0.999982` instead of `1`.

## Root cause

`www/web-gui/public/market.js`, line 545:

```js
parseFloat((item.bid_balance_value * item.display_price).toPrecision(6))
```

For a token with 0 decimals, `display_price` is the ratio `ask/bid` as a float (e.g. `0.008525` for ~117 MMX/TRAIL). Multiplying by `bid_balance_value` (117.3) gives `0.9999825` due to IEEE 754 precision loss. The on-chain contract uses integer math (`(deposit_amount × inv_price) >> 64`) and gets exactly `1`.

## Evidence

API response for a BUY offer (bid=MMX, ask=TRAIL, 0 decimals):

```json
{
  "ask_amount": "1",
  "ask_value": 1.0,
  "bid_balance": "117300000",
  "bid_balance_value": 117.3,
  "display_price": 0.008525
}
```

- GUI shows: `117.3 × 0.008525 = 0.9999825 → "0.999982" ❌
- Should show: `1` (from `ask_value`) ✅

The **My Offers** table on the same page (line 656) already does it correctly:
```js
<b>{{item.ask_value}}</b>&nbsp;
```

## Fix

One-line change — use `ask_value` from the API instead of recomputing:

```diff
- <b>{{parseFloat((item.bid_balance_value * item.display_price).toPrecision(6))}}</b>&nbsp;
+ <b>{{item.ask_value}}</b>&nbsp;
```

## Impact

Any token with 0 decimals will show fractional phantom amounts in the offers table. Purely cosmetic — the chain and API are correct — but confusing for users. Tested with TRAIL token (0 decimals) on MMX mainnet.